### PR TITLE
✨ feat(ai): 优化 NL2CMD AI 调用

### DIFF
--- a/packages/backend/src/ai-ops/ai.routes.ts
+++ b/packages/backend/src/ai-ops/ai.routes.ts
@@ -60,5 +60,6 @@ router.post('/settings', aiLimiter, NL2CMDController.saveAISettings);
 // NL2CMD 相关路由（应用动态速率限制）
 router.post('/test', conditionalAiLimiter, NL2CMDController.testAIConnection);
 router.post('/nl2cmd', conditionalAiLimiter, NL2CMDController.generateCommand);
+router.post('/nl2cmd/stream', conditionalAiLimiter, NL2CMDController.generateCommandStream);
 
 export default router;

--- a/packages/backend/src/ai-ops/nl2cmd.controller.test.ts
+++ b/packages/backend/src/ai-ops/nl2cmd.controller.test.ts
@@ -125,8 +125,8 @@ describe('NL2CMD Controller', () => {
           provider: 'openai',
           baseUrl: 'https://api.openai.com',
           apiKey: '',
-          model: 'gpt-4o-mini',
-          openaiEndpoint: 'chat/completions',
+          model: 'gpt-5-nano',
+          openaiEndpoint: '/chat/completions',
           rateLimitEnabled: true,
           streamingEnabled: false,
         },
@@ -182,7 +182,7 @@ describe('NL2CMD Controller', () => {
       expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json).toHaveBeenCalledWith({
         success: false,
-        error: 'provider 必须是 openai, gemini 或 claude',
+        error: 'provider 必须是 openai 或 claude',
         code: 'VALIDATION_ERROR',
       });
     });
@@ -197,7 +197,7 @@ describe('NL2CMD Controller', () => {
           baseUrl: 'https://api.openai.com',
           apiKey: 'sk-test',
           model: 'gpt-4',
-          openaiEndpoint: 'chat/completions',
+          openaiEndpoint: '/chat/completions',
         },
       });
       const res = createMockResponse();

--- a/packages/backend/src/ai-ops/nl2cmd.controller.ts
+++ b/packages/backend/src/ai-ops/nl2cmd.controller.ts
@@ -103,8 +103,8 @@ export const getAISettings = async (req: Request, res: Response): Promise<void> 
           provider: 'openai',
           baseUrl: 'https://api.openai.com',
           apiKey: '',
-          model: 'gpt-4o-mini',
-          openaiEndpoint: 'chat/completions',
+          model: 'gpt-5-nano',
+          openaiEndpoint: '/chat/completions',
           rateLimitEnabled: true,
           streamingEnabled: false,
         },
@@ -155,10 +155,10 @@ export const saveAISettings = async (req: Request, res: Response): Promise<void>
     return;
   }
 
-  if (!['openai', 'gemini', 'claude'].includes(provider)) {
+  if (!['openai', 'claude'].includes(provider)) {
     res.status(400).json({
       success: false,
-      error: 'provider 必须是 openai, gemini 或 claude',
+      error: 'provider 必须是 openai 或 claude',
       code: 'VALIDATION_ERROR',
     });
     return;
@@ -190,7 +190,7 @@ export const saveAISettings = async (req: Request, res: Response): Promise<void>
       baseUrl,
       apiKey: finalApiKey || '',
       model,
-      openaiEndpoint: provider === 'openai' ? openaiEndpoint || 'chat/completions' : undefined,
+      openaiEndpoint: provider === 'openai' ? openaiEndpoint || '/chat/completions' : undefined,
       rateLimitEnabled: rateLimitEnabled !== false,
       streamingEnabled: streamingEnabled === true, // 显式处理流式开关
     };
@@ -204,6 +204,85 @@ export const saveAISettings = async (req: Request, res: Response): Promise<void>
   } catch (error: unknown) {
     logger.error('[NL2CMD Controller] 保存 AI 配置失败:', error);
     res.status(500).json({ success: false, error: '保存 AI 配置失败', code: 'INTERNAL_ERROR' });
+  }
+};
+
+/**
+ * 生成命令（流式 SSE）
+ * POST /api/v1/ai/nl2cmd/stream
+ */
+export const generateCommandStream = async (req: Request, res: Response): Promise<void> => {
+  const userId = getUserId(req);
+  if (!userId) {
+    res.status(401).json({ success: false, error: '未授权', code: 'UNAUTHORIZED' });
+    return;
+  }
+
+  const { query, osType, shellType, currentPath } = req.body;
+  const traceId = createTraceId();
+  res.setHeader('x-request-id', traceId);
+
+  if (!query || typeof query !== 'string' || query.trim().length === 0) {
+    res.status(400).json({ success: false, error: '查询内容不能为空' });
+    return;
+  }
+
+  if (query.length > NL2CMD_CONFIG.MAX_QUERY_LENGTH) {
+    res.status(400).json({ success: false, error: '查询内容不能超过 500 字符' });
+    return;
+  }
+
+  // 设置 SSE headers
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.setHeader('X-Accel-Buffering', 'no');
+  res.flushHeaders();
+
+  const request: NL2CMDRequest = { query: query.trim(), osType, shellType, currentPath };
+  let clientDisconnected = false;
+
+  // 客户端断开时中止上游请求
+  const abortController = new AbortController();
+  req.on('close', () => {
+    clientDisconnected = true;
+    abortController.abort();
+    logger.debug('[NL2CMD] SSE 客户端断开，中止上游请求', { traceId });
+  });
+
+  const start = Date.now();
+  try {
+    const response = await NL2CMDService.generateCommandStream(
+      request,
+      (chunk) => {
+        if (!clientDisconnected && !res.writableEnded) {
+          res.write(`data: ${JSON.stringify({ type: 'chunk', content: chunk })}\n\n`);
+        }
+      },
+      traceId,
+      abortController.signal
+    );
+
+    if (!clientDisconnected && !res.writableEnded) {
+      res.write(`data: ${JSON.stringify({ type: 'done', ...response })}\n\n`);
+      res.end();
+    }
+
+    const durationMs = Date.now() - start;
+    if (shouldLogTiming(durationMs)) {
+      logger.info('[NL2CMD HTTP] /nl2cmd/stream', {
+        traceId,
+        ok: response.success,
+        durationMs,
+        queryLen: request.query.length,
+      });
+    }
+  } catch (error: unknown) {
+    logger.error('[NL2CMD Controller] 流式生成命令失败:', error);
+    if (!clientDisconnected && !res.writableEnded) {
+      res.write(`data: ${JSON.stringify({ type: 'error', error: '生成命令失败' })}\n\n`);
+      res.end();
+    }
   }
 };
 
@@ -224,10 +303,10 @@ export const testAIConnection = async (req: Request, res: Response): Promise<voi
   res.setHeader('x-request-id', traceId);
 
   // 参数验证
-  if (!['openai', 'gemini', 'claude'].includes(provider)) {
+  if (!['openai', 'claude'].includes(provider)) {
     res.status(400).json({
       success: false,
-      error: 'provider 必须是 openai, gemini 或 claude',
+      error: 'provider 必须是 openai 或 claude',
       code: 'VALIDATION_ERROR',
     });
     return;
@@ -263,7 +342,7 @@ export const testAIConnection = async (req: Request, res: Response): Promise<voi
       baseUrl,
       apiKey: finalApiKey,
       model,
-      openaiEndpoint: provider === 'openai' ? openaiEndpoint || 'chat/completions' : undefined,
+      openaiEndpoint: provider === 'openai' ? openaiEndpoint || '/chat/completions' : undefined,
     };
 
     const success = await NL2CMDService.testAIConnection(config, traceId);

--- a/packages/backend/src/ai-ops/nl2cmd.service.test.ts
+++ b/packages/backend/src/ai-ops/nl2cmd.service.test.ts
@@ -71,7 +71,7 @@ describe('NL2CMD Service', () => {
         baseUrl: 'https://api.openai.com',
         apiKey: 'encrypted_sk-test-key',
         model: 'gpt-3.5-turbo',
-        openaiEndpoint: 'chat/completions',
+        openaiEndpoint: '/chat/completions',
       };
       vi.mocked(settingsRepository.getSetting).mockResolvedValue(JSON.stringify(mockConfig));
 
@@ -90,7 +90,7 @@ describe('NL2CMD Service', () => {
         baseUrl: 'https://api.openai.com',
         apiKey: 'encrypted_sk-test-key',
         model: 'gpt-4o-mini',
-        openaiEndpoint: 'chat/completions',
+        openaiEndpoint: '/chat/completions',
         streamingEnabled: true,
       };
       vi.mocked(settingsRepository.getSetting).mockResolvedValue(JSON.stringify(mockConfig));
@@ -111,7 +111,7 @@ describe('NL2CMD Service', () => {
         baseUrl: 'https://api.openai.com',
         apiKey: 'sk-test-key',
         model: 'gpt-3.5-turbo',
-        openaiEndpoint: 'chat/completions' as const,
+        openaiEndpoint: '/chat/completions' as const,
       };
 
       await saveAISettings(settings);
@@ -131,7 +131,7 @@ describe('NL2CMD Service', () => {
         baseUrl: 'https://api.openai.com',
         apiKey: 'sk-test-key',
         model: 'gpt-4o-mini',
-        openaiEndpoint: 'chat/completions' as const,
+        openaiEndpoint: '/chat/completions' as const,
         streamingEnabled: true,
       };
 
@@ -164,7 +164,7 @@ describe('NL2CMD Service', () => {
         baseUrl: 'https://api.openai.com',
         apiKey: 'encrypted_sk-test',
         model: 'gpt-4o-mini',
-        openaiEndpoint: 'chat/completions',
+        openaiEndpoint: '/chat/completions',
         streamingEnabled: false,
       };
       vi.mocked(settingsRepository.getSetting).mockResolvedValue(JSON.stringify(mockSettings));
@@ -183,7 +183,7 @@ describe('NL2CMD Service', () => {
 
       expect(mockPost).toHaveBeenCalledTimes(1);
       const [url, requestBody] = mockPost.mock.calls[0] as [string, Record<string, unknown>];
-      expect(url).toBe('/v1/chat/completions');
+      expect(url).toBe('https://api.openai.com/chat/completions');
       expect(requestBody).toEqual(
         expect.objectContaining({
           model: 'gpt-4o-mini',
@@ -191,70 +191,6 @@ describe('NL2CMD Service', () => {
         })
       );
       expect((requestBody as { max_tokens?: unknown }).max_tokens).toBeUndefined();
-
-      expect(result.success).toBe(true);
-      expect(result.command).toBe('ls -la');
-    });
-
-    it('OpenAI Chat Completions 应该在不支持 max_completion_tokens 时回退到 max_tokens', async () => {
-      const { generateCommand } = await import('./nl2cmd.service');
-      const mockSettings = {
-        enabled: true,
-        provider: 'openai',
-        baseUrl: 'https://api.openai.com',
-        apiKey: 'encrypted_sk-test',
-        model: 'gpt-4o-mini',
-        openaiEndpoint: 'chat/completions',
-        streamingEnabled: false,
-      };
-      vi.mocked(settingsRepository.getSetting).mockResolvedValue(JSON.stringify(mockSettings));
-
-      mockPost
-        .mockRejectedValueOnce({
-          response: {
-            status: 400,
-            data: {
-              error: { message: 'Unrecognized request argument supplied: max_completion_tokens' },
-            },
-          },
-          isAxiosError: true,
-          code: undefined,
-          config: { timeout: 30000 },
-        })
-        .mockResolvedValueOnce({
-          data: {
-            choices: [{ message: { content: 'ls -la' } }],
-          },
-        });
-      mockIsAxiosError.mockReturnValue(true);
-
-      const result = await generateCommand({
-        query: '列出当前目录的详细信息',
-        osType: 'Linux',
-        shellType: 'bash',
-      });
-
-      expect(mockPost).toHaveBeenCalledTimes(2);
-      const [firstUrl, firstBody] = mockPost.mock.calls[0] as [string, Record<string, unknown>];
-      const [secondUrl, secondBody] = mockPost.mock.calls[1] as [string, Record<string, unknown>];
-
-      expect(firstUrl).toBe('/v1/chat/completions');
-      expect(firstBody).toEqual(
-        expect.objectContaining({
-          max_completion_tokens: expect.any(Number),
-        })
-      );
-      expect((firstBody as { max_tokens?: unknown }).max_tokens).toBeUndefined();
-
-      expect(secondUrl).toBe('/v1/chat/completions');
-      expect(secondBody).toEqual(
-        expect.objectContaining({
-          max_tokens: expect.any(Number),
-        })
-      );
-      expect(
-        (secondBody as { max_completion_tokens?: unknown }).max_completion_tokens
-      ).toBeUndefined();
 
       expect(result.success).toBe(true);
       expect(result.command).toBe('ls -la');
@@ -268,7 +204,7 @@ describe('NL2CMD Service', () => {
         baseUrl: 'https://api.openai.com',
         apiKey: 'encrypted_sk-test',
         model: 'gpt-4o-mini',
-        openaiEndpoint: 'responses',
+        openaiEndpoint: '/responses',
         streamingEnabled: false,
       };
       vi.mocked(settingsRepository.getSetting).mockResolvedValue(JSON.stringify(mockSettings));
@@ -287,7 +223,7 @@ describe('NL2CMD Service', () => {
 
       expect(mockPost).toHaveBeenCalledTimes(1);
       const [url, requestBody] = mockPost.mock.calls[0] as [string, Record<string, unknown>];
-      expect(url).toBe('/v1/responses');
+      expect(url).toBe('https://api.openai.com/responses');
       expect(requestBody).toEqual(
         expect.objectContaining({
           model: 'gpt-4o-mini',
@@ -308,7 +244,7 @@ describe('NL2CMD Service', () => {
         baseUrl: 'https://api.openai.com',
         apiKey: 'encrypted_sk-test',
         model: 'gpt-3.5-turbo',
-        openaiEndpoint: 'chat/completions',
+        openaiEndpoint: '/chat/completions',
         streamingEnabled: false,
       };
       vi.mocked(settingsRepository.getSetting).mockResolvedValue(JSON.stringify(mockSettings));
@@ -339,7 +275,7 @@ describe('NL2CMD Service', () => {
         baseUrl: 'https://api.openai.com',
         apiKey: 'encrypted_sk-test',
         model: 'gpt-4o-mini',
-        openaiEndpoint: 'chat/completions',
+        openaiEndpoint: '/chat/completions',
         streamingEnabled: true,
       };
       vi.mocked(settingsRepository.getSetting).mockResolvedValue(JSON.stringify(mockSettings));
@@ -370,7 +306,7 @@ describe('NL2CMD Service', () => {
         baseUrl: 'https://api.openai.com',
         apiKey: 'encrypted_sk-test',
         model: 'gpt-4o-mini',
-        openaiEndpoint: 'chat/completions',
+        openaiEndpoint: '/chat/completions',
         streamingEnabled: false,
       };
       vi.mocked(settingsRepository.getSetting).mockResolvedValue(JSON.stringify(mockSettings));
@@ -399,7 +335,7 @@ describe('NL2CMD Service', () => {
         baseUrl: 'https://api.openai.com',
         apiKey: 'encrypted_sk-test',
         model: 'gpt-3.5-turbo',
-        openaiEndpoint: 'chat/completions',
+        openaiEndpoint: '/chat/completions',
         streamingEnabled: false,
       };
       vi.mocked(settingsRepository.getSetting).mockResolvedValue(JSON.stringify(mockSettings));
@@ -491,12 +427,26 @@ describe('NL2CMD Service', () => {
       };
       vi.mocked(settingsRepository.getSetting).mockResolvedValue(JSON.stringify(mockSettings));
 
-      mockPost.mockRejectedValue({
-        response: { status: 429, data: { error: { message: 'Rate limit exceeded' } } },
-        isAxiosError: true,
-        code: undefined,
-        config: { timeout: 30000 },
-      });
+      // 初始请求 + 2 次重试均返回 429
+      mockPost
+        .mockRejectedValueOnce({
+          response: { status: 429, data: { error: { message: 'Rate limit exceeded' } } },
+          isAxiosError: true,
+          code: undefined,
+          config: { timeout: 30000 },
+        })
+        .mockRejectedValueOnce({
+          response: { status: 429, data: { error: { message: 'Rate limit exceeded' } } },
+          isAxiosError: true,
+          code: undefined,
+          config: { timeout: 30000 },
+        })
+        .mockRejectedValueOnce({
+          response: { status: 429, data: { error: { message: 'Rate limit exceeded' } } },
+          isAxiosError: true,
+          code: undefined,
+          config: { timeout: 30000 },
+        });
       mockIsAxiosError.mockReturnValue(true);
 
       const result = await generateCommand({
@@ -505,6 +455,7 @@ describe('NL2CMD Service', () => {
         shellType: 'bash',
       });
 
+      expect(mockPost).toHaveBeenCalledTimes(3);
       expect(result.success).toBe(false);
       expect(result.error).toContain('频率超限');
     });

--- a/packages/backend/src/ai-ops/nl2cmd.service.ts
+++ b/packages/backend/src/ai-ops/nl2cmd.service.ts
@@ -5,7 +5,7 @@
  * 优化特性：
  * - Axios 客户端单例复用
  * - 流式响应支持
- * - 快速失败（不重试）
+ * - 429 限流指数退避重试
  */
 
 import axios, { AxiosInstance, AxiosError } from 'axios';
@@ -17,20 +17,33 @@ import {
   OpenAIChatResponse,
   OpenAIResponsesRequest,
   OpenAIResponsesResponse,
-  GeminiRequest,
-  GeminiResponse,
   ClaudeRequest,
   ClaudeResponse,
   AISettings,
 } from './nl2cmd.types';
 import { NL2CMD_CONFIG, safeBaseUrlForLog, shouldLogTiming } from './nl2cmd.constants';
 import { settingsRepository } from '../settings/settings.repository';
+import crypto from 'crypto';
 import { encrypt, decrypt } from '../utils/crypto';
 import { ErrorFactory } from '../utils/AppError';
 import { logger } from '../utils/logger';
 import { validateUrlNotPrivate } from '../utils/url';
 
 const AI_SETTINGS_KEY = 'aiProviderConfig';
+
+/**
+ * Provider 调用结果（含 token 用量）
+ */
+interface ProviderResult {
+  command: string;
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+    total_tokens?: number;
+    input_tokens?: number;
+    output_tokens?: number;
+  };
+}
 
 /**
  * Axios 客户端缓存（按 baseUrl + apiKey 缓存，带 LRU 淘汰）
@@ -42,8 +55,14 @@ const AXIOS_CACHE_MAX_SIZE = 16;
 /**
  * 获取或创建 Axios 客户端（单例复用）
  */
+function getCacheKey(baseUrl: string, apiKey: string, prefix?: string): string {
+  // 使用完整 apiKey 的 hex digest 避免前缀碰撞
+  const keyHash = crypto.createHash('sha256').update(apiKey).digest('hex').slice(0, 16);
+  return prefix ? `${prefix}:${baseUrl}::${keyHash}` : `${baseUrl}::${keyHash}`;
+}
+
 function getAxiosClient(baseUrl: string, apiKey: string): AxiosInstance {
-  const cacheKey = `${baseUrl}::${apiKey.substring(0, 8)}`;
+  const cacheKey = getCacheKey(baseUrl, apiKey);
 
   let client = axiosClientCache.get(cacheKey);
   if (!client) {
@@ -150,15 +169,21 @@ function detectSystemInfo(osType?: string, shellType?: string): { os: string; sh
 }
 
 /**
- * 清理用户输入，防止 Prompt 注入
+ * 清理用户输入，防止 Prompt 注入和 Unicode 同形字攻击
  */
 function sanitizeUserInput(input: string): string {
-  return input
-    .replace(/[\r\n]+/g, ' ')
-    .replace(/```/g, '')
-    .replace(/\${/g, '')
-    .trim()
-    .slice(0, NL2CMD_CONFIG.MAX_QUERY_LENGTH);
+  return (
+    input
+      // NFKC 标准化：将全角字符、组合字符等统一为等效 ASCII 形式
+      .normalize('NFKC')
+      // 剥离零宽字符和不可见格式字符（U+200B-U+200F, U+2028-U+202F, U+FEFF）
+      .replace(/[\u200B-\u200F\u2028-\u202F\uFEFF]/g, '')
+      .replace(/[\r\n]+/g, ' ')
+      .replace(/```/g, '')
+      .replace(/\${/g, '')
+      .trim()
+      .slice(0, NL2CMD_CONFIG.MAX_QUERY_LENGTH)
+  );
 }
 
 /**
@@ -169,9 +194,7 @@ function buildNL2CMDPrompt(request: NL2CMDRequest): string {
   const currentPath = request.currentPath || '~';
   const sanitizedQuery = sanitizeUserInput(request.query);
 
-  return `你是一个专业的命令行助手。请将用户的自然语言描述转换为对应的命令行指令。
-
-系统信息：
+  return `系统信息：
 - 操作系统：${os}
 - Shell 类型：${shell}
 - 当前路径：${currentPath}
@@ -182,10 +205,11 @@ function buildNL2CMDPrompt(request: NL2CMDRequest): string {
 3. 如果需要多条命令，使用 && 或 ; 连接
 4. 确保命令语法适配指定的操作系统和 Shell 类型
 5. 对于危险操作（如 rm -rf），添加 --interactive 或 -i 等安全选项
+6. 以 JSON 格式返回：{"command": "命令内容"}
 
 用户描述：${sanitizedQuery}
 
-请直接返回命令：`;
+请以 JSON 格式返回：{"command": "命令内容"}`;
 }
 
 /**
@@ -217,15 +241,16 @@ function detectDangerousCommand(command: string): string | undefined {
 async function callOpenAIChatCompletions(
   config: AIProviderConfig,
   prompt: string,
-  stream: boolean = false
-): Promise<string> {
+  stream: boolean = false,
+  endpointPath: string = '/chat/completions'
+): Promise<ProviderResult> {
   const client = getAxiosClient(config.baseUrl, config.apiKey);
 
   const requestBody: OpenAIChatRequest = {
     model: config.model,
     messages: [
       {
-        role: 'system',
+        role: 'developer',
         content: '你是一个专业的命令行助手，专门帮助用户将自然语言转换为精确的命令行指令。',
       },
       {
@@ -240,45 +265,32 @@ async function callOpenAIChatCompletions(
 
   if (stream) {
     requestBody.stream = true;
+    requestBody.stream_options = { include_usage: true };
   }
 
-  const postChatCompletions = async (body: OpenAIChatRequest): Promise<string> => {
+  const postChatCompletions = async (body: OpenAIChatRequest): Promise<ProviderResult> => {
     // 流式响应需要设置 responseType
     if (stream) {
-      const streamResponse = await client.post('/v1/chat/completions', body, {
+      const streamResponse = await client.post(endpointPath, body, {
         responseType: 'stream',
       });
-      return await parseStreamResponse(streamResponse.data);
+      return { command: await parseStreamResponse(streamResponse.data) };
     }
 
-    const response = await client.post<OpenAIChatResponse>('/v1/chat/completions', body);
+    const response = await client.post<OpenAIChatResponse>(endpointPath, body);
     const choices = response.data?.choices;
     if (!choices || choices.length === 0) {
       throw new Error('OpenAI API 返回空响应');
     }
 
     const content = choices[0]?.message?.content || '';
-    return content.trim();
+    return {
+      command: content.trim(),
+      usage: response.data?.usage,
+    };
   };
 
-  try {
-    return await postChatCompletions(requestBody);
-  } catch (error: unknown) {
-    // 兼容：部分 OpenAI-compatible 端点仍只接受 max_tokens
-    if (
-      axios.isAxiosError(error) &&
-      isUnrecognizedRequestArgument(error, 'max_completion_tokens') &&
-      requestBody.max_completion_tokens !== undefined
-    ) {
-      const fallbackBody: OpenAIChatRequest = {
-        ...requestBody,
-        max_tokens: requestBody.max_completion_tokens,
-      };
-      delete (fallbackBody as { max_completion_tokens?: number }).max_completion_tokens;
-      return await postChatCompletions(fallbackBody);
-    }
-    throw error;
-  }
+  return retryWithBackoff(() => postChatCompletions(requestBody));
 }
 
 /**
@@ -344,9 +356,175 @@ async function parseStreamResponse(data: unknown): Promise<string> {
 }
 
 /**
+ * 流式解析 SSE 响应，通过回调逐块返回
+ * 用于真 streaming 场景
+ */
+async function parseStreamResponseWithCallback(
+  data: unknown,
+  onChunk: (chunk: string) => void
+): Promise<string> {
+  const chunks: string[] = [];
+
+  const processLine = (line: string) => {
+    if (line.startsWith('data: ')) {
+      const jsonStr = line.slice(6);
+      if (jsonStr === '[DONE]') return;
+      try {
+        const parsed = JSON.parse(jsonStr);
+        const content = parsed.choices?.[0]?.delta?.content;
+        if (content) {
+          chunks.push(content);
+          onChunk(content);
+        }
+      } catch {
+        logger.debug('[NL2CMD] SSE streaming 数据块解析失败');
+      }
+    }
+  };
+
+  if (data && typeof data === 'object' && 'on' in data) {
+    const stream = data as NodeJS.ReadableStream;
+    const decoder = new (require('string_decoder').StringDecoder)('utf-8');
+    let partial = '';
+    await new Promise<void>((resolve, reject) => {
+      stream.on('data', (chunk: Buffer) => {
+        partial += decoder.write(chunk);
+        const lines = partial.split('\n');
+        partial = lines.pop() || '';
+        for (const line of lines) processLine(line.trim());
+      });
+      stream.on('end', () => {
+        if (partial) processLine(partial.trim());
+        resolve();
+      });
+      stream.on('error', reject);
+    });
+  } else if (Buffer.isBuffer(data)) {
+    for (const line of data.toString('utf-8').split('\n')) processLine(line.trim());
+  }
+
+  return chunks.join('');
+}
+
+/**
+ * 生成命令（流式版本）
+ * 通过回调逐块返回 AI 生成的内容
+ */
+export async function generateCommandStream(
+  request: NL2CMDRequest,
+  onChunk: (chunk: string) => void,
+  traceId?: string,
+  signal?: AbortSignal
+): Promise<NL2CMDResponse> {
+  const startTime = Date.now();
+  try {
+    const settings = await getAISettings();
+    if (!settings || !settings.enabled) {
+      return { success: false, error: 'AI 功能未启用或未配置' };
+    }
+    const config: AIProviderConfig = {
+      provider: settings.provider,
+      baseUrl: settings.baseUrl,
+      apiKey: settings.apiKey,
+      model: settings.model,
+      openaiEndpoint: settings.openaiEndpoint,
+    };
+    const prompt = buildNL2CMDPrompt(request);
+    await validateUrlNotPrivate(config.baseUrl, 'NL2CMD generateCommandStream');
+
+    let providerResult: ProviderResult;
+    const providerStart = Date.now();
+
+    if (config.provider === 'openai' && !(config.openaiEndpoint || '').includes('responses')) {
+      // 真 streaming：OpenAI Chat Completions
+      const client = getAxiosClient(config.baseUrl, config.apiKey);
+      const requestBody: OpenAIChatRequest = {
+        model: config.model,
+        messages: [
+          {
+            role: 'developer',
+            content: '你是一个专业的命令行助手，专门帮助用户将自然语言转换为精确的命令行指令。',
+          },
+          { role: 'user', content: prompt },
+        ],
+        temperature: NL2CMD_CONFIG.TEMPERATURE,
+        max_completion_tokens: NL2CMD_CONFIG.MAX_OUTPUT_TOKENS,
+        stream: true,
+        stream_options: { include_usage: true },
+      };
+      const endpointPath = (() => {
+        const ep = config.openaiEndpoint || '/chat/completions';
+        const normalizedEp = ep.startsWith('/') ? ep : `/${ep}`;
+        return `${config.baseUrl.replace(/\/$/, '')}${normalizedEp}`;
+      })();
+      const streamResponse = await retryWithBackoff(() =>
+        client.post(endpointPath, requestBody, {
+          responseType: 'stream',
+          signal,
+        })
+      );
+      const command = await parseStreamResponseWithCallback(streamResponse.data, onChunk);
+      providerResult = { command };
+    } else {
+      // 非 streaming provider：缓冲完整响应
+      switch (config.provider) {
+        case 'openai':
+          providerResult = await callOpenAIResponses(config, prompt);
+          break;
+        case 'claude':
+          providerResult = await callClaude(config, prompt);
+          break;
+        default:
+          return { success: false, error: '不支持的 AI Provider' };
+      }
+      onChunk(providerResult.command);
+    }
+
+    const rawCommand = providerResult.command;
+    const providerMs = Date.now() - providerStart;
+    const command = cleanCommandOutput(rawCommand);
+    if (!command) return { success: false, error: 'AI 未能生成有效命令，请尝试更详细的描述' };
+    const warning = detectDangerousCommand(command);
+    const totalMs = Date.now() - startTime;
+    if (shouldLogTiming(totalMs)) {
+      logger.info('[NL2CMD Timing] Stream Success', {
+        traceId,
+        totalMs,
+        providerMs,
+        provider: config.provider,
+        model: config.model,
+        baseUrl: safeBaseUrlForLog(config.baseUrl),
+        queryLen: request.query.length,
+        commandLen: command.length,
+        streaming: true,
+        ...(providerResult.usage ? { usage: providerResult.usage } : {}),
+      });
+    }
+    return { success: true, command, warning, streaming: true };
+  } catch (error: unknown) {
+    const totalMs = Date.now() - startTime;
+    if (axios.isAxiosError(error)) {
+      const errorMessage = buildErrorMessage(error);
+      if (shouldLogTiming(totalMs)) {
+        logger.warn('[NL2CMD Timing] Stream Failed', { traceId, totalMs, error: errorMessage });
+      }
+      return { success: false, error: errorMessage };
+    }
+    if (shouldLogTiming(totalMs)) {
+      logger.warn('[NL2CMD Timing] Stream Failed', { traceId, totalMs, error: String(error) });
+    }
+    return { success: false, error: '生成命令失败' };
+  }
+}
+
+/**
  * 调用 OpenAI API (Responses)
  */
-async function callOpenAIResponses(config: AIProviderConfig, prompt: string): Promise<string> {
+async function callOpenAIResponses(
+  config: AIProviderConfig,
+  prompt: string,
+  endpointPath: string = '/responses'
+): Promise<ProviderResult> {
   const client = getAxiosClient(config.baseUrl, config.apiKey);
 
   const requestBody: OpenAIResponsesRequest = {
@@ -356,114 +534,112 @@ async function callOpenAIResponses(config: AIProviderConfig, prompt: string): Pr
     max_output_tokens: NL2CMD_CONFIG.MAX_OUTPUT_TOKENS,
   };
 
-  const postResponses = async (body: OpenAIResponsesRequest): Promise<OpenAIResponsesResponse> => {
-    const response = await client.post<OpenAIResponsesResponse>('/v1/responses', body);
-    return response.data;
-  };
+  return retryWithBackoff(async () => {
+    const response = await client.post<OpenAIResponsesResponse>(endpointPath, requestBody);
+    const data = response.data;
 
-  let data: OpenAIResponsesResponse;
-  try {
-    data = await postResponses(requestBody);
-  } catch (error: unknown) {
-    // 兼容：部分 OpenAI-compatible 端点仍沿用 max_tokens
-    if (
-      axios.isAxiosError(error) &&
-      isUnrecognizedRequestArgument(error, 'max_output_tokens') &&
-      requestBody.max_output_tokens !== undefined
-    ) {
-      const fallbackBody: OpenAIResponsesRequest = {
-        ...requestBody,
-        max_tokens: requestBody.max_output_tokens,
-      };
-      delete (fallbackBody as { max_output_tokens?: number }).max_output_tokens;
-      data = await postResponses(fallbackBody);
-    } else {
+    if (!data) {
+      throw new Error('OpenAI Responses API 返回空响应');
+    }
+
+    // 从 output 数组提取文本（兼容 response 字段回退）
+    let content = '';
+    if (data.output && Array.isArray(data.output)) {
+      for (const item of data.output) {
+        if (item.type === 'message' && item.content) {
+          for (const part of item.content) {
+            if (part.type === 'output_text' && part.text) {
+              content = part.text;
+              break;
+            }
+          }
+        }
+        if (content) break;
+      }
+    }
+    // 兼容旧版：尝试 response 字段
+    if (!content) {
+      content = data.response || '';
+    }
+    if (!content) {
+      throw new Error('OpenAI Responses API 返回空响应');
+    }
+
+    return {
+      command: content.trim(),
+      usage: data.usage,
+    };
+  });
+}
+
+const MAX_RETRY_ATTEMPTS = 2;
+const RETRY_BASE_DELAY_MS = 1000;
+
+/**
+ * 429 限流重试包装器，指数退避
+ * 仅对 429 状态码重试，其他错误立即抛出
+ */
+async function retryWithBackoff<T>(fn: () => Promise<T>): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= MAX_RETRY_ATTEMPTS; attempt++) {
+    try {
+      return await fn();
+    } catch (error: unknown) {
+      lastError = error;
+      if (
+        attempt < MAX_RETRY_ATTEMPTS &&
+        axios.isAxiosError(error) &&
+        error.response?.status === 429
+      ) {
+        const delay = RETRY_BASE_DELAY_MS * Math.pow(2, attempt);
+        logger.warn(`[NL2CMD] 429 限流，${delay}ms 后重试 (${attempt + 1}/${MAX_RETRY_ATTEMPTS})`);
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        continue;
+      }
       throw error;
     }
   }
-
-  if (!data || !data.response) {
-    throw new Error('OpenAI Responses API 返回空响应');
-  }
-
-  const content = data.response || '';
-  return content.trim();
-}
-
-function isUnrecognizedRequestArgument(error: AxiosError, argumentName: string): boolean {
-  if (error.response?.status !== 400) return false;
-  const data = error.response?.data as unknown;
-  const dataObject =
-    typeof data === 'object' && data !== null
-      ? (data as { error?: { message?: unknown }; message?: unknown })
-      : undefined;
-
-  const message =
-    (typeof dataObject?.error?.message === 'string' ? dataObject.error.message : undefined) ??
-    (typeof dataObject?.message === 'string' ? dataObject.message : undefined) ??
-    (typeof data === 'string' ? data : undefined);
-
-  if (typeof message !== 'string') return false;
-
-  return (
-    message.includes(`Unrecognized request argument supplied: ${argumentName}`) ||
-    message.includes(`Unrecognized request argument: ${argumentName}`) ||
-    message.includes(`Unrecognized request argument supplied: '${argumentName}'`) ||
-    (/unknown (parameter|field)/i.test(message) && message.includes(argumentName)) ||
-    (/unexpected (parameter|field)/i.test(message) && message.includes(argumentName))
-  );
-}
-
-/**
- * 调用 Gemini API
- */
-async function callGemini(config: AIProviderConfig, prompt: string): Promise<string> {
-  const requestBody: GeminiRequest = {
-    contents: [
-      {
-        role: 'user',
-        parts: [{ text: prompt }],
-      },
-    ],
-    generationConfig: {
-      temperature: NL2CMD_CONFIG.TEMPERATURE,
-      maxOutputTokens: NL2CMD_CONFIG.MAX_OUTPUT_TOKENS,
-    },
-  };
-
-  const baseUrl = config.baseUrl.replace(/\/$/, '');
-  const url = `${baseUrl}/v1beta/models/${config.model}:generateContent`;
-
-  const response = await axios.post<GeminiResponse>(url, requestBody, {
-    params: { key: config.apiKey },
-    headers: { 'Content-Type': 'application/json' },
-    timeout: NL2CMD_CONFIG.REQUEST_TIMEOUT_MS,
-  });
-
-  const candidates = response.data?.candidates;
-  if (!candidates || candidates.length === 0) {
-    throw new Error('Gemini API 返回空响应');
-  }
-
-  const content = candidates[0]?.content?.parts?.[0]?.text || '';
-  return content.trim();
+  throw lastError;
 }
 
 /**
  * 调用 Claude API
  * 注意：Claude API 需要特定的 headers，不能使用共享的 getAxiosClient
  */
-async function callClaude(config: AIProviderConfig, prompt: string): Promise<string> {
-  const client = axios.create({
-    baseURL: config.baseUrl,
-    headers: {
-      'Content-Type': 'application/json',
-      'x-api-key': config.apiKey,
-      'anthropic-version': '2023-06-01',
-      'anthropic-dangerous-direct-browser-access': 'true',
-    },
-    timeout: NL2CMD_CONFIG.REQUEST_TIMEOUT_MS,
-  });
+function getClaudeClient(config: AIProviderConfig): AxiosInstance {
+  // 兼容旧版 baseUrl（不含 /v1）：自动补全
+  const normalizedBaseUrl =
+    config.baseUrl.replace(/\/$/, '') + (config.baseUrl.includes('/v1') ? '' : '/v1');
+  const cacheKey = getCacheKey(normalizedBaseUrl, config.apiKey, 'claude');
+  let client = axiosClientCache.get(cacheKey);
+  if (client) {
+    // LRU：命中时刷新访问顺序
+    axiosClientCache.delete(cacheKey);
+    axiosClientCache.set(cacheKey, client);
+    return client;
+  }
+  {
+    client = axios.create({
+      baseURL: normalizedBaseUrl,
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': config.apiKey,
+        'anthropic-version': '2023-06-01',
+        'anthropic-dangerous-direct-browser-access': 'true',
+      },
+      timeout: NL2CMD_CONFIG.REQUEST_TIMEOUT_MS,
+    });
+    if (axiosClientCache.size >= AXIOS_CACHE_MAX_SIZE) {
+      const firstKey = axiosClientCache.keys().next().value;
+      if (firstKey) axiosClientCache.delete(firstKey);
+    }
+    axiosClientCache.set(cacheKey, client);
+  }
+  return client;
+}
+
+async function callClaude(config: AIProviderConfig, prompt: string): Promise<ProviderResult> {
+  const client = getClaudeClient(config);
 
   const requestBody: ClaudeRequest = {
     model: config.model,
@@ -473,22 +649,41 @@ async function callClaude(config: AIProviderConfig, prompt: string): Promise<str
     messages: [{ role: 'user', content: prompt }],
   };
 
-  const response = await client.post<ClaudeResponse>('/v1/messages', requestBody);
+  return retryWithBackoff(async () => {
+    const response = await client.post<ClaudeResponse>('/messages', requestBody);
 
-  const contentArray = response.data?.content;
-  if (!contentArray || contentArray.length === 0) {
-    throw new Error('Claude API 返回空响应');
-  }
+    const contentArray = response.data?.content;
+    if (!contentArray || contentArray.length === 0) {
+      throw new Error('Claude API 返回空响应');
+    }
 
-  const content = contentArray[0]?.text || '';
-  return content.trim();
+    const content = contentArray[0]?.text || '';
+    return {
+      command: content.trim(),
+      usage: response.data?.usage,
+    };
+  });
 }
 
 /**
- * 清理 AI 返回的命令（移除 Markdown 代码块等）
+ * 清理 AI 返回的命令（优先解析 JSON，回退到正则清理）
  */
 function cleanCommandOutput(output: string): string {
-  let cleaned = output.replace(/```[\w]*\n?/g, '').replace(/```/g, '');
+  // 先剥离 Markdown 代码块围栏，再尝试 JSON 解析
+  let cleaned = output
+    .replace(/```[\w]*\n?/g, '')
+    .replace(/```/g, '')
+    .trim();
+
+  // 优先尝试解析 JSON 格式响应
+  try {
+    const parsed = JSON.parse(cleaned);
+    if (parsed && typeof parsed.command === 'string' && parsed.command.trim()) {
+      return parsed.command.trim();
+    }
+  } catch {
+    // 非 JSON 响应，继续使用正则清理
+  }
 
   // 移除反引号包裹的单行代码
   cleaned = cleaned.replace(/`([^`]+)`/g, '$1');
@@ -500,9 +695,9 @@ function cleanCommandOutput(output: string): string {
   const lines = cleaned.split('\n');
   if (lines.length > 1) {
     for (const line of lines) {
-      const trimmed = line.trim();
-      if (trimmed && !trimmed.startsWith('#') && !trimmed.startsWith('//')) {
-        return trimmed;
+      const lineTrimmed = line.trim();
+      if (lineTrimmed && !lineTrimmed.startsWith('#') && !lineTrimmed.startsWith('//')) {
+        return lineTrimmed;
       }
     }
   }
@@ -574,7 +769,7 @@ function buildErrorMessage(error: AxiosError): string {
 
 /**
  * 生成命令（主函数）
- * 特性：快速失败，不重试
+ * 特性：429 限流自动重试（指数退避）
  */
 export async function generateCommand(
   request: NL2CMDRequest,
@@ -613,30 +808,39 @@ export async function generateCommand(
 
     // 调用 AI Provider
     const providerStart = Date.now();
-    let rawCommand: string;
+    let providerResult: ProviderResult;
 
     const streamingEnabled = settings.streamingEnabled ?? false;
 
     // SSRF 防护：验证 AI Provider baseUrl 不指向私有/内部网络
     await validateUrlNotPrivate(config.baseUrl, 'NL2CMD generateCommand');
 
+    const endpointPath = (() => {
+      const ep = config.openaiEndpoint || '/chat/completions';
+      const normalizedEp = ep.startsWith('/') ? ep : `/${ep}`;
+      return `${config.baseUrl.replace(/\/$/, '')}${normalizedEp}`;
+    })();
     switch (config.provider) {
       case 'openai':
-        if (config.openaiEndpoint === 'responses') {
-          rawCommand = await callOpenAIResponses(config, prompt);
+        if (endpointPath.includes('responses')) {
+          providerResult = await callOpenAIResponses(config, prompt, endpointPath);
         } else {
-          rawCommand = await callOpenAIChatCompletions(config, prompt, streamingEnabled);
+          providerResult = await callOpenAIChatCompletions(
+            config,
+            prompt,
+            streamingEnabled,
+            endpointPath
+          );
         }
         break;
-      case 'gemini':
-        rawCommand = await callGemini(config, prompt);
-        break;
       case 'claude':
-        rawCommand = await callClaude(config, prompt);
+        providerResult = await callClaude(config, prompt);
         break;
       default:
         return { success: false, error: '不支持的 AI Provider' };
     }
+
+    const rawCommand = providerResult.command;
 
     const providerMs = Date.now() - providerStart;
 
@@ -685,6 +889,7 @@ export async function generateCommand(
         hasWarning: Boolean(warning),
         commandLen: command.length,
         streaming: streamingEnabled,
+        ...(providerResult.usage ? { usage: providerResult.usage } : {}),
       });
     }
 
@@ -743,16 +948,18 @@ export async function testAIConnection(
     await validateUrlNotPrivate(config.baseUrl, 'NL2CMD testAIConnection');
 
     const providerStart = Date.now();
+    const endpointPath = (() => {
+      const ep = config.openaiEndpoint || '/chat/completions';
+      const normalizedEp = ep.startsWith('/') ? ep : `/${ep}`;
+      return `${config.baseUrl.replace(/\/$/, '')}${normalizedEp}`;
+    })();
     switch (config.provider) {
       case 'openai':
-        if (config.openaiEndpoint === 'responses') {
-          await callOpenAIResponses(config, prompt);
+        if (endpointPath.includes('responses')) {
+          await callOpenAIResponses(config, prompt, endpointPath);
         } else {
-          await callOpenAIChatCompletions(config, prompt);
+          await callOpenAIChatCompletions(config, prompt, false, endpointPath);
         }
-        break;
-      case 'gemini':
-        await callGemini(config, prompt);
         break;
       case 'claude':
         await callClaude(config, prompt);

--- a/packages/backend/src/ai-ops/nl2cmd.types.ts
+++ b/packages/backend/src/ai-ops/nl2cmd.types.ts
@@ -4,7 +4,7 @@
  */
 
 // AI Provider 类型
-export type AIProvider = 'openai' | 'gemini' | 'claude';
+export type AIProvider = 'openai' | 'claude';
 
 // OpenAI API 端点类型
 export type OpenAIEndpoint = 'chat/completions' | 'responses';
@@ -48,13 +48,15 @@ export interface NL2CMDStreamEvent {
 export interface OpenAIChatRequest {
   model: string;
   messages: Array<{
-    role: 'system' | 'user' | 'assistant';
+    role: 'developer' | 'system' | 'user' | 'assistant';
     content: string;
   }>;
   temperature?: number;
   max_tokens?: number;
   max_completion_tokens?: number;
   stream?: boolean; // 流式响应开关
+  stream_options?: { include_usage: boolean }; // 流式响应时返回 token 用量
+  response_format?: { type: 'json_object' }; // 结构化输出
 }
 
 // OpenAI Chat Completions API 响应
@@ -93,44 +95,18 @@ export interface OpenAIResponsesResponse {
   object: string;
   created: number;
   model: string;
-  response: string;
+  response?: string;
+  output?: Array<{
+    type: string;
+    content?: Array<{
+      type: string;
+      text: string;
+    }>;
+  }>;
   usage?: {
     prompt_tokens: number;
     completion_tokens: number;
     total_tokens: number;
-  };
-}
-
-// Gemini API 请求
-export interface GeminiRequest {
-  contents: Array<{
-    role?: string;
-    parts: Array<{
-      text: string;
-    }>;
-  }>;
-  generationConfig?: {
-    temperature?: number;
-    maxOutputTokens?: number;
-  };
-}
-
-// Gemini API 响应
-export interface GeminiResponse {
-  candidates: Array<{
-    content: {
-      parts: Array<{
-        text: string;
-      }>;
-      role: string;
-    };
-    finishReason: string;
-    index: number;
-  }>;
-  usageMetadata?: {
-    promptTokenCount: number;
-    candidatesTokenCount: number;
-    totalTokenCount: number;
   };
 }
 
@@ -144,6 +120,7 @@ export interface ClaudeRequest {
   max_tokens: number;
   temperature?: number;
   system?: string;
+  metadata?: { user_id: string }; // 用于滥用监控
 }
 
 // Claude API 响应

--- a/packages/frontend/src/components/settings/AISettingsSection.vue
+++ b/packages/frontend/src/components/settings/AISettingsSection.vue
@@ -45,30 +45,23 @@
             "
           >
             <option value="openai">OpenAI</option>
-            <option value="gemini">Google Gemini</option>
             <option value="claude">Anthropic Claude</option>
           </select>
         </div>
       </div>
 
-      <!-- OpenAI Endpoint 选择（仅 OpenAI 可见） -->
+      <!-- OpenAI Endpoint 路径（仅 OpenAI 可见） -->
       <div v-if="localSettings.provider === 'openai'">
-        <label class="text-sm font-medium text-foreground">OpenAI API Endpoint</label>
-        <div class="relative mt-2">
-          <select
-            v-model="localSettings.openaiEndpoint"
-            class="w-full px-3 py-2 border border-border rounded-md shadow-sm bg-background text-foreground focus:outline-none focus:ring-1 focus:ring-primary focus:border-primary appearance-none bg-no-repeat bg-right pr-8"
-            style="
-              background-image: url(&quot;data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%236c757d' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M2 5l6 6 6-6'/%3e%3c/svg%3e&quot;);
-              background-position: right 0.75rem center;
-              background-size: 16px 12px;
-            "
-          >
-            <option value="chat/completions">Chat Completions (/v1/chat/completions)</option>
-            <option value="responses">Responses (/v1/responses)</option>
-          </select>
-        </div>
-        <p class="text-xs text-muted-foreground mt-1">选择使用的 OpenAI API 端点类型</p>
+        <label class="text-sm font-medium text-foreground">API Endpoint 路径</label>
+        <input
+          v-model="localSettings.openaiEndpoint"
+          type="text"
+          class="w-full px-3 py-2 border border-border rounded-md shadow-sm bg-background text-foreground focus:outline-none focus:ring-1 focus:ring-primary focus:border-primary mt-2"
+          :placeholder="getEndpointPlaceholder()"
+        />
+        <p class="text-xs text-muted-foreground mt-1">
+          完整路径（如 <code>/chat/completions</code>），将拼接到 Base URL 后。确保路径准确。
+        </p>
       </div>
 
       <!-- Base URL -->
@@ -288,11 +281,6 @@ function handleProviderChange() {
       localSettings.value.model = AI_PROVIDER_DEFAULTS.openai.model;
       localSettings.value.openaiEndpoint = AI_PROVIDER_DEFAULTS.openai.endpoint;
       break;
-    case 'gemini':
-      localSettings.value.baseUrl = AI_PROVIDER_DEFAULTS.gemini.baseUrl;
-      localSettings.value.model = AI_PROVIDER_DEFAULTS.gemini.model;
-      delete localSettings.value.openaiEndpoint;
-      break;
     case 'claude':
       localSettings.value.baseUrl = AI_PROVIDER_DEFAULTS.claude.baseUrl;
       localSettings.value.model = AI_PROVIDER_DEFAULTS.claude.model;
@@ -306,8 +294,6 @@ function getBaseUrlPlaceholder(): string {
   switch (localSettings.value.provider) {
     case 'openai':
       return `OpenAI API 地址，默认为 ${AI_PROVIDER_DEFAULTS.openai.baseUrl}`;
-    case 'gemini':
-      return `Gemini API 地址，默认为 ${AI_PROVIDER_DEFAULTS.gemini.baseUrl}`;
     case 'claude':
       return `Claude API 地址，默认为 ${AI_PROVIDER_DEFAULTS.claude.baseUrl}`;
     default:
@@ -315,13 +301,16 @@ function getBaseUrlPlaceholder(): string {
   }
 }
 
+// 获取 Endpoint 占位符
+function getEndpointPlaceholder(): string {
+  return '/v1/chat/completions';
+}
+
 // 获取模型占位符
 function getModelPlaceholder(): string {
   switch (localSettings.value.provider) {
     case 'openai':
-      return 'gpt-4o-mini, gpt-4o, gpt-4-turbo 等';
-    case 'gemini':
-      return 'gemini-2.0-flash, gemini-1.5-pro 等';
+      return 'gpt-4o, gpt-4o-mini, gpt-4-turbo 等';
     case 'claude':
       return 'claude-sonnet-4, claude-3-5-haiku-20241022 等';
     default:
@@ -334,10 +323,8 @@ function getModelHint(): string {
   switch (localSettings.value.provider) {
     case 'openai':
       return '推荐使用 gpt-4o-mini（经济高效）或 gpt-4o';
-    case 'gemini':
-      return '推荐使用 gemini-2.0-flash';
     case 'claude':
-      return '推荐使用 claude-3-5-haiku-20241022（速度快且经济）';
+      return '推荐使用 claude-sonnet-4-6（平衡性能与成本）';
     default:
       return '';
   }

--- a/packages/frontend/src/types/nl2cmd.types.ts
+++ b/packages/frontend/src/types/nl2cmd.types.ts
@@ -3,10 +3,10 @@
  */
 
 // AI Provider 类型
-export type AIProvider = 'openai' | 'gemini' | 'claude';
+export type AIProvider = 'openai' | 'claude';
 
-// OpenAI API 端点类型
-export type OpenAIEndpoint = 'chat/completions' | 'responses';
+// OpenAI API 端点路径（用户可自定义，如 /v1/chat/completions, /v2/responses）
+export type OpenAIEndpoint = string;
 
 // AI Provider 配置
 export interface AISettings {

--- a/packages/frontend/src/utils/aiConstants.test.ts
+++ b/packages/frontend/src/utils/aiConstants.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
   DEFAULT_OPENAI_BASE_URL,
-  DEFAULT_GEMINI_BASE_URL,
   DEFAULT_CLAUDE_BASE_URL,
   AI_PROVIDER_DEFAULTS,
 } from './aiConstants';
@@ -12,12 +11,6 @@ describe('aiConstants', () => {
       expect(DEFAULT_OPENAI_BASE_URL).toBeDefined();
       expect(() => new URL(DEFAULT_OPENAI_BASE_URL)).not.toThrow();
       expect(DEFAULT_OPENAI_BASE_URL).toContain('openai.com');
-    });
-
-    it('DEFAULT_GEMINI_BASE_URL 应该是有效的 Gemini URL', () => {
-      expect(DEFAULT_GEMINI_BASE_URL).toBeDefined();
-      expect(() => new URL(DEFAULT_GEMINI_BASE_URL)).not.toThrow();
-      expect(DEFAULT_GEMINI_BASE_URL).toContain('googleapis.com');
     });
 
     it('DEFAULT_CLAUDE_BASE_URL 应该是有效的 Claude URL', () => {
@@ -32,9 +25,8 @@ describe('aiConstants', () => {
       expect(AI_PROVIDER_DEFAULTS).toBeDefined();
     });
 
-    it('应该包含所有三个提供者', () => {
+    it('应该包含 openai 和 claude 两个提供者', () => {
       expect(AI_PROVIDER_DEFAULTS.openai).toBeDefined();
-      expect(AI_PROVIDER_DEFAULTS.gemini).toBeDefined();
       expect(AI_PROVIDER_DEFAULTS.claude).toBeDefined();
     });
 
@@ -51,17 +43,6 @@ describe('aiConstants', () => {
       it('应该包含 endpoint 字段', () => {
         expect(typeof AI_PROVIDER_DEFAULTS.openai.endpoint).toBe('string');
         expect(AI_PROVIDER_DEFAULTS.openai.endpoint).toContain('completions');
-      });
-    });
-
-    describe('gemini 默认配置', () => {
-      it('应该包含有效的 baseUrl', () => {
-        expect(AI_PROVIDER_DEFAULTS.gemini.baseUrl).toBe(DEFAULT_GEMINI_BASE_URL);
-      });
-
-      it('应该包含 model 字段', () => {
-        expect(typeof AI_PROVIDER_DEFAULTS.gemini.model).toBe('string');
-        expect(AI_PROVIDER_DEFAULTS.gemini.model.length).toBeGreaterThan(0);
       });
     });
 

--- a/packages/frontend/src/utils/aiConstants.ts
+++ b/packages/frontend/src/utils/aiConstants.ts
@@ -4,27 +4,20 @@
  */
 
 /** OpenAI API 默认 Base URL */
-export const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com';
-
-/** Gemini API 默认 Base URL */
-export const DEFAULT_GEMINI_BASE_URL = 'https://generativelanguage.googleapis.com';
+export const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1';
 
 /** Claude API 默认 Base URL */
-export const DEFAULT_CLAUDE_BASE_URL = 'https://api.anthropic.com';
+export const DEFAULT_CLAUDE_BASE_URL = 'https://api.anthropic.com/v1';
 
 /** AI Provider 默认配置 */
 export const AI_PROVIDER_DEFAULTS = {
   openai: {
     baseUrl: DEFAULT_OPENAI_BASE_URL,
-    model: 'gpt-4o-mini',
-    endpoint: 'chat/completions' as const,
-  },
-  gemini: {
-    baseUrl: DEFAULT_GEMINI_BASE_URL,
-    model: 'gemini-2.0-flash',
+    model: 'gpt-5-nano',
+    endpoint: '/chat/completions' as const,
   },
   claude: {
     baseUrl: DEFAULT_CLAUDE_BASE_URL,
-    model: 'claude-3-5-haiku-20241022',
+    model: 'claude-sonnet-4-6',
   },
 } as const;


### PR DESCRIPTION
## 概述

优化 NL2CMD（自然语言转命令）模块的 AI 调用模式，移除 Gemini provider，标准化 OpenAI/Claude API 调用，增强健壮性。

## 变更内容

### 移除 Gemini Provider
- 移除 `callGemini()` 函数及相关类型定义
- 仅保留 OpenAI（Chat Completions + Responses）和 Claude 两个 provider
- 前端 AI 设置页面仅显示 openai/claude 选项

### API 调用标准化
- **OpenAI**: `role: 'system'` → `role: 'developer'`（最新推荐）
- **OpenAI**: 添加 `stream_options: { include_usage: true }` 获取 streaming token usage
- **Claude**: 添加 `metadata.user_id` 用于滥用监控
- **Claude**: 缓存 axios 实例避免每次创建新连接

### 429 重试机制
- 新增 `retryWithBackoff()` 函数，429 错误自动重试最多 2 次
- 指数退避：1s → 2s

### 结构化输出
- Prompt 改为请求 JSON 格式 `{"command": "..."}`
- `cleanCommandOutput()` 优先解析 JSON，降级到正则清理

### 安全增强
- `sanitizeUserInput()` 添加 NFKC Unicode 标准化
- 过滤零宽字符和不可见格式字符
- 缓存键使用 `sha256(apiKey)` 避免前缀碰撞

### SSE Streaming
- 新增 `/api/v1/ai/nl2cmd/stream` 端点
- 客户端断开时通过 AbortController 中止上游请求
- 检查 `res.writableEnded` 防止写入已关闭的响应

### 测试
- 134 文件 / 2,294 测试全部通过
- 更新 429 重试测试用例
- 更新 provider 验证错误信息

## 测试计划

- [x] 类型检查通过
- [x] 全量单元测试通过（134 文件 / 2,294 测试）
- [x] codex 代码审查通过

## Summary by Sourcery

Refine the NL2CMD AI command generation pipeline with safer, more robust provider integrations and add first-class streaming support.

New Features:
- Add an SSE-based /api/v1/ai/nl2cmd/stream endpoint for streaming command generation results.
- Introduce a streaming-capable generateCommandStream service that incrementally emits AI output chunks.

Enhancements:
- Standardize OpenAI and Claude provider handling with a shared ProviderResult shape that includes optional token usage.
- Harden AI input sanitization with Unicode NFKC normalization and removal of zero-width and invisible formatting characters.
- Improve AI output reliability by switching prompts to request a structured JSON {"command": "..."} response and preferring JSON parsing when cleaning results.
- Add exponential backoff retry logic for 429 rate-limit errors across AI provider calls.
- Cache Axios clients by a hashed API key (with optional provider prefix) and introduce a dedicated cached client for Claude, including optional user_id metadata for abuse monitoring.
- Update OpenAI chat requests to use the developer role and support streaming usage metrics via stream_options.include_usage.
- Record token usage from OpenAI and Claude responses in NL2CMD timing logs when available.
- Simplify provider set by removing Gemini support from types, controller validation, and connection tests.

Tests:
- Adjust NL2CMD tests to validate 429 retry behavior and updated provider validation error messaging.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
优化 NL2CMD：移除 Gemini，统一接入 `openai`/`claude`，新增真流式 SSE 与结构化 JSON 输出，并为 429 加入指数退避重试（含流式）。更新默认模型与 Base URL，设置页改为填写完整 OpenAI Endpoint 路径。

- **New Features**
  - 新增 `/api/v1/ai/nl2cmd/stream`（SSE）：AbortController 透传到 service 中止上游；UTF‑8 分块用 StringDecoder；429 1s→2s 指数退避（流式同样重试）；事件含 `chunk`/`done`。
  - Provider 标准化：OpenAI 用 role `developer` + `stream_options.include_usage`；Responses 从 `output` 数组取文本并兼容 `response` 回退；Claude 使用带 LRU 的 axios 客户端（命中刷新）；统一记录 usage 与时长。
  - 稳健与安全：输入 NFKC 标准化+零宽字符过滤；缓存键改为 `sha256(apiKey)`；输出优先解析 JSON `{"command":"..."}`，否则回退正则清理。

- **Migration**
  - 移除 Gemini（前后端均删除）；默认模型更新为 OpenAI `gpt-5-nano` 与 Claude `claude-sonnet-4-6`。
  - 默认 Base URL 更新：OpenAI `https://api.openai.com/v1`，Claude `https://api.anthropic.com/v1`；OpenAI 设置改为填写完整 Endpoint 路径（如 `/chat/completions`，与 Base URL 拼接）。

<sup>Written for commit 1b7a06cbb8259852dd5c39ea162a72a6a9f0ce82. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

