### PR TITLE
✨ feat(mobile): 重构虚拟键盘布局并优化移动端体验

### DIFF
--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="src/assets/logo.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>Nexus Terminal</title>
     <meta name="theme-color" content="#9370DB" />
     <!-- PWA 支持：iOS -->

--- a/packages/frontend/src/components/VirtualKeyboard.vue
+++ b/packages/frontend/src/components/VirtualKeyboard.vue
@@ -1,24 +1,76 @@
 <template>
   <div class="virtual-keyboard-sticky bg-background border-t border-border p-1 pb-2 select-none">
-    <!-- Row 1: 功能键 + 修饰键 + 方向键 -->
-    <div class="flex overflow-x-auto gap-1.5 px-2 pb-1.5 hide-scrollbar items-center">
+    <!-- Row 1: 修饰键 + 功能键 -->
+    <div class="flex flex-wrap gap-1 px-2 pb-1.5 items-center">
       <button
-        v-for="key in stickyKeys"
+        v-for="key in row1Keys"
         :key="key.label"
         @click="handleKeyClick(key)"
-        class="flex-shrink-0 min-w-[2.75rem] h-9 px-1.5 rounded font-medium text-xs border border-border bg-input text-foreground active:bg-primary active:text-white transition-colors select-none flex items-center justify-center touch-manipulation"
+        class="min-w-[2.75rem] h-9 px-1.5 rounded font-medium text-xs border border-border bg-input text-foreground active:bg-primary active:text-white transition-colors select-none flex items-center justify-center touch-manipulation"
         :class="{ 'bg-primary text-white': isActiveModifier(key.label) }"
       >
         {{ key.label }}
       </button>
     </div>
-    <!-- Row 2: 字母键（用于 Ctrl/Alt 组合） -->
-    <div class="flex overflow-x-auto gap-1 px-2 hide-scrollbar items-center">
+    <!-- Row 2: 导航键 + F1-F3 -->
+    <div class="flex flex-wrap gap-1 px-2 pb-1.5 items-center">
       <button
-        v-for="letter in letterKeys"
+        v-for="key in row2Keys"
+        :key="key.label"
+        @click="handleKeyClick(key)"
+        class="min-w-[2.75rem] h-9 px-1.5 rounded font-medium text-xs border border-border bg-input text-foreground active:bg-primary active:text-white transition-colors select-none flex items-center justify-center touch-manipulation"
+      >
+        {{ key.label }}
+      </button>
+    </div>
+    <!-- Row 3: F4-F11 -->
+    <div class="flex flex-wrap gap-1 px-2 pb-1.5 items-center">
+      <button
+        v-for="key in row3Keys"
+        :key="key.label"
+        @click="handleKeyClick(key)"
+        class="min-w-[2.75rem] h-9 px-1.5 rounded font-medium text-xs border border-border bg-input text-foreground active:bg-primary active:text-white transition-colors select-none flex items-center justify-center touch-manipulation"
+      >
+        {{ key.label }}
+      </button>
+    </div>
+    <!-- Row 4: F12 + A-H -->
+    <div class="flex flex-wrap gap-1 px-2 pb-1 items-center">
+      <button
+        v-for="letter in row4Keys"
         :key="letter"
         @click="handleLetterClick(letter)"
-        class="flex-shrink-0 w-8 h-8 rounded font-medium text-xs border border-border bg-input text-foreground active:bg-primary active:text-white transition-colors select-none flex items-center justify-center touch-manipulation"
+        class="w-8 h-8 rounded font-medium text-xs border border-border bg-input text-foreground active:bg-primary active:text-white transition-colors select-none flex items-center justify-center touch-manipulation"
+        :class="{
+          'bg-primary text-white': isCtrlActive || isAltActive,
+          'border-primary/50': isCtrlActive || isAltActive,
+        }"
+      >
+        {{ letter }}
+      </button>
+    </div>
+    <!-- Row 5: I-Q -->
+    <div class="flex flex-wrap gap-1 px-2 pb-1 items-center">
+      <button
+        v-for="letter in row5Letters"
+        :key="letter"
+        @click="handleLetterClick(letter)"
+        class="w-8 h-8 rounded font-medium text-xs border border-border bg-input text-foreground active:bg-primary active:text-white transition-colors select-none flex items-center justify-center touch-manipulation"
+        :class="{
+          'bg-primary text-white': isCtrlActive || isAltActive,
+          'border-primary/50': isCtrlActive || isAltActive,
+        }"
+      >
+        {{ letter }}
+      </button>
+    </div>
+    <!-- Row 6: R-Z -->
+    <div class="flex flex-wrap gap-1 px-2 items-center">
+      <button
+        v-for="letter in row6Letters"
+        :key="letter"
+        @click="handleLetterClick(letter)"
+        class="w-8 h-8 rounded font-medium text-xs border border-border bg-input text-foreground active:bg-primary active:text-white transition-colors select-none flex items-center justify-center touch-manipulation"
         :class="{
           'bg-primary text-white': isCtrlActive || isAltActive,
           'border-primary/50': isCtrlActive || isAltActive,
@@ -46,22 +98,50 @@ interface KeyDef {
   isModifier?: boolean;
 }
 
-const stickyKeys: KeyDef[] = [
-  { label: 'Esc', sequence: '\x1b' },
-  { label: 'Tab', sequence: '\t' },
+// Row 1: Ctrl, Alt, Tab, Esc, ↑, ↓, ←, →
+const row1Keys: KeyDef[] = [
   { label: 'Ctrl', isModifier: true },
   { label: 'Alt', isModifier: true },
-  { label: '←', sequence: '\x1b[D' },
-  { label: '↓', sequence: '\x1b[B' },
+  { label: 'Tab', sequence: '\t' },
+  { label: 'Esc', sequence: '\x1b' },
   { label: '↑', sequence: '\x1b[A' },
+  { label: '↓', sequence: '\x1b[B' },
+  { label: '←', sequence: '\x1b[D' },
   { label: '→', sequence: '\x1b[C' },
+];
+
+// Row 2: Home, End, PgUp, PgDn, F1, F2, F3
+const row2Keys: KeyDef[] = [
   { label: 'Home', sequence: '\x1b[H' },
   { label: 'End', sequence: '\x1b[F' },
   { label: 'PgUp', sequence: '\x1b[5~' },
   { label: 'PgDn', sequence: '\x1b[6~' },
+  { label: 'F1', sequence: '\x1bOP' },
+  { label: 'F2', sequence: '\x1bOQ' },
+  { label: 'F3', sequence: '\x1bOR' },
 ];
 
-const letterKeys = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
+// Row 3: F4-F11
+const row3Keys: KeyDef[] = [
+  { label: 'F4', sequence: '\x1bOS' },
+  { label: 'F5', sequence: '\x1b[15~' },
+  { label: 'F6', sequence: '\x1b[17~' },
+  { label: 'F7', sequence: '\x1b[18~' },
+  { label: 'F8', sequence: '\x1b[19~' },
+  { label: 'F9', sequence: '\x1b[20~' },
+  { label: 'F10', sequence: '\x1b[21~' },
+  { label: 'F11', sequence: '\x1b[23~' },
+];
+
+// Row 4: F12 + A-H (F12 是功能键，其余是字母键)
+const row4Keys = ['F12', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'];
+const F12_SEQUENCE = '\x1b[24~';
+
+// Row 5: I-Q
+const row5Letters = ['I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q'];
+
+// Row 6: R-Z
+const row6Letters = ['R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'];
 
 const isActiveModifier = (label: string) => {
   if (label === 'Ctrl') return isCtrlActive.value;
@@ -81,11 +161,6 @@ const handleKeyClick = (key: KeyDef) => {
 
   let sequence = key.sequence || key.label;
 
-  // 应用 Ctrl 修饰符（功能键的 Ctrl 组合暂不处理，仅处理字母键）
-  if (isCtrlActive.value && !key.sequence) {
-    sequence = getCtrlSequence(key.label);
-  }
-
   // 应用 Alt 修饰符
   if (isAltActive.value) {
     sequence = '\x1b' + sequence;
@@ -99,12 +174,14 @@ const handleKeyClick = (key: KeyDef) => {
 };
 
 /**
- * 处理字母键点击
+ * 处理字母键 / F12 点击
  */
 const handleLetterClick = (letter: string) => {
   let sequence: string;
 
-  if (isCtrlActive.value) {
+  if (letter === 'F12') {
+    sequence = F12_SEQUENCE;
+  } else if (isCtrlActive.value) {
     // Ctrl+字母：发送 ASCII 控制字符（Ctrl+A=0x01, Ctrl+C=0x03, ..., Ctrl+Z=0x1A）
     sequence = getCtrlSequence(letter);
   } else if (isAltActive.value) {
@@ -139,13 +216,6 @@ const getCtrlSequence = (char: string): string => {
 </script>
 
 <style scoped>
-.hide-scrollbar::-webkit-scrollbar {
-  display: none;
-}
-.hide-scrollbar {
-  -ms-overflow-style: none;
-  scrollbar-width: none;
-}
 .touch-manipulation {
   touch-action: manipulation;
 }

--- a/packages/frontend/src/style.css
+++ b/packages/frontend/src/style.css
@@ -411,3 +411,31 @@ button:hover {
     justify-content: center;
   }
 }
+
+/* ==========================================
+   移动端安全区域适配 (iPhone 刘海 / Dynamic Island)
+   ========================================== */
+@supports (padding: env(safe-area-inset-top)) {
+  body {
+    padding-top: env(safe-area-inset-top);
+    padding-bottom: env(safe-area-inset-bottom);
+    padding-left: env(safe-area-inset-left);
+    padding-right: env(safe-area-inset-right);
+  }
+}
+
+/* ==========================================
+   移动端滚动行为优化
+   ========================================== */
+/* 防止终端区域的过度滚动导致页面弹性回弹干扰 */
+html {
+  overscroll-behavior: none;
+}
+
+/* 触屏设备禁止文本选择（终端场景不需要） */
+@media (hover: none) and (pointer: coarse) {
+  .xterm-screen {
+    -webkit-user-select: none;
+    user-select: none;
+  }
+}


### PR DESCRIPTION
## Summary
- 虚拟键盘重构为 6 行网格布局，新增 F1-F12 功能键，按键排列对齐设计稿
- viewport 禁止缩放防止移动端误触放大
- 添加 iPhone 安全区域适配（safe-area-inset）
- 终端区域禁止过度滚动回弹干扰
- 触屏设备禁止终端文本选择

## Test plan
- [x] VirtualKeyboard 单元测试通过
- [x] TypeScript 类型检查通过
- [ ] 移动端实机验证虚拟键盘布局
- [ ] iPhone 安全区域适配验证

## Summary by Sourcery

Refactor the on-screen virtual keyboard into a multi-row layout with expanded function keys and optimize mobile viewport, safe-area handling, and terminal interaction on touch devices.

New Features:
- Introduce a six-row virtual keyboard layout including F1–F12 and reorganized modifier, navigation, and letter keys for better mobile usability.

Enhancements:
- Adjust key grouping and styling in the virtual keyboard for a grid-like, wrap-friendly layout aligned with design specifications.
- Handle F12 input within the letter/click handler to support its use alongside modifier logic.

Chores:
- Disable viewport zooming on mobile to prevent accidental page scaling.
- Add global CSS safe-area insets support for iOS devices.
- Prevent overscroll bounce on the page to avoid interference with the terminal region.
- Disable text selection in the terminal screen on touch devices to improve interaction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilt the mobile virtual keyboard into a 6-row grid and added F1–F12 to improve reach and accuracy. Also improved mobile UX with safe‑area support, disabled zoom, and smoother terminal scrolling.

- **New Features**
  - 6-row virtual keyboard with grouped modifiers, navigation, and letters to match the design.
  - Added F1–F12 support; proper escape sequences for navigation and function keys.
  - Disabled viewport zoom to prevent accidental pinch-zoom.
  - iPhone safe-area insets via `env(safe-area-inset-*)`.
  - Disabled terminal overscroll bounce and touch text selection on mobile.

<sup>Written for commit 8c47bb184454850058c6cf6e7c6e81183809260b. Summary will update on new commits. <a href="https://cubic.dev/pr/Silentely/nexus-terminal/pull/73?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

