### PR TITLE
🐛 fix(settings): 修复设置页面开关脱钩、保存失败回滚、按钮重复提交等问题

### DIFF
--- a/packages/frontend/src/components/settings/AISettingsSection.vue
+++ b/packages/frontend/src/components/settings/AISettingsSection.vue
@@ -170,6 +170,9 @@
         <p class="text-xs text-muted-foreground mt-1 ml-6">
           开启后 AI 请求/响应详情将输出到浏览器控制台和容器日志，用于排查问题
         </p>
+        <p class="text-xs text-warning mt-1 ml-6 italic">
+          注意：调试模式为会话级设置，页面刷新后将自动关闭
+        </p>
       </div>
 
       <!-- 操作按钮 -->
@@ -301,7 +304,7 @@ function handleProviderChange() {
     case 'claude':
       localSettings.value.baseUrl = AI_PROVIDER_DEFAULTS.claude.baseUrl;
       localSettings.value.model = AI_PROVIDER_DEFAULTS.claude.model;
-      delete localSettings.value.openaiEndpoint;
+      localSettings.value.openaiEndpoint = undefined;
       break;
   }
 }

--- a/packages/frontend/src/components/settings/AppearanceSection.vue
+++ b/packages/frontend/src/components/settings/AppearanceSection.vue
@@ -25,15 +25,13 @@
 </template>
 
 <script setup lang="ts">
-import { useSettingsStore } from '../../stores/settings.store';
-import { useAppearanceStore } from '../../stores/appearance.store';
 import { useI18n } from 'vue-i18n';
+import { useSettingsStore } from '../../stores/settings.store';
 import { storeToRefs } from 'pinia';
 import { useAppearanceSettings } from '../../composables/settings/useAppearanceSettings';
 
 const settingsStore = useSettingsStore();
 const { settings } = storeToRefs(settingsStore);
-const appearanceStore = useAppearanceStore();
 const { t } = useI18n();
 
 const { openStyleCustomizer } = useAppearanceSettings();

--- a/packages/frontend/src/components/settings/CaptchaSettingsForm.vue
+++ b/packages/frontend/src/components/settings/CaptchaSettingsForm.vue
@@ -98,6 +98,12 @@
           <small class="block mt-1 text-xs text-text-secondary">{{
             $t('settings.captcha.secretKeyHint')
           }}</small>
+          <small class="block mt-1 text-xs text-warning italic">{{
+            $t(
+              'settings.captcha.secretKeyEmptyHint',
+              '留空则保留原有密钥，如需清除请填写新值后保存。'
+            )
+          }}</small>
         </div>
       </div>
 
@@ -146,6 +152,12 @@
           <small class="block mt-1 text-xs text-text-secondary">{{
             $t('settings.captcha.secretKeyHint')
           }}</small>
+          <small class="block mt-1 text-xs text-warning italic">{{
+            $t(
+              'settings.captcha.secretKeyEmptyHint',
+              '留空则保留原有密钥，如需清除请填写新值后保存。'
+            )
+          }}</small>
         </div>
       </div>
 
@@ -154,9 +166,11 @@
         <button
           type="submit"
           :disabled="captchaLoading"
-          class="px-4 py-2 bg-button text-button-text rounded-md shadow-sm hover:bg-button-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition duration-150 ease-in-out text-sm font-medium"
+          class="px-4 py-2 bg-button text-button-text rounded-md shadow-sm hover:bg-button-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition duration-150 ease-in-out text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          {{ $t('settings.captcha.saveButton') }}
+          {{
+            captchaLoading ? $t('common.saving', '保存中...') : $t('settings.captcha.saveButton')
+          }}
         </button>
         <p
           v-if="captchaMessage"
@@ -170,12 +184,9 @@
 </template>
 
 <script setup lang="ts">
-import { useI18n } from 'vue-i18n';
 import { storeToRefs } from 'pinia';
 import { useCaptchaSettingsStore } from '../../stores/captchaSettings.store';
 import { useCaptchaSettings } from '../../composables/settings/useCaptchaSettings';
-
-// const { t } = useI18n(); // $t is globally available in template
 const captchaStore = useCaptchaSettingsStore();
 const { captchaSettings, captchaError } = storeToRefs(captchaStore); // To make v-if="!captchaSettings" reactive
 

--- a/packages/frontend/src/components/settings/IpBlacklistSettings.vue
+++ b/packages/frontend/src/components/settings/IpBlacklistSettings.vue
@@ -181,6 +181,10 @@
           {{ blacklistDeleteError }}
         </p>
       </div>
+      <!-- Toggle Error -->
+      <p v-if="ipBlacklistToggleError" class="mt-3 text-sm text-error">
+        {{ ipBlacklistToggleError }}
+      </p>
       <!-- End v-if="ipBlacklistEnabled" -->
       <!-- Message when disabled -->
       <div
@@ -194,13 +198,11 @@
 </template>
 
 <script setup lang="ts">
-import { useI18n } from 'vue-i18n';
 import { useIpBlacklist } from '../../composables/settings/useIpBlacklist';
-
-// const { t } = useI18n(); // $t is globally available in template
 
 const {
   ipBlacklistEnabled,
+  ipBlacklistToggleError,
   handleUpdateIpBlacklistEnabled,
   blacklistSettingsForm,
   // blacklistSettingsLoading, // Not used directly in template, handled by form submit button state

--- a/packages/frontend/src/components/settings/PasskeyManagement.vue
+++ b/packages/frontend/src/components/settings/PasskeyManagement.vue
@@ -138,10 +138,7 @@
 </template>
 
 <script setup lang="ts">
-import { useI18n } from 'vue-i18n';
 import { usePasskeyManagement } from '../../composables/settings/usePasskeyManagement';
-
-// const { t } = useI18n(); // $t is globally available in template
 
 const {
   passkeys,

--- a/packages/frontend/src/components/settings/TwoFactorAuthSettings.vue
+++ b/packages/frontend/src/components/settings/TwoFactorAuthSettings.vue
@@ -108,10 +108,7 @@
 </template>
 
 <script setup lang="ts">
-import { useI18n } from 'vue-i18n';
 import { useTwoFactorAuth } from '../../composables/settings/useTwoFactorAuth';
-
-// const { t } = useI18n(); // $t is globally available in template
 
 const {
   twoFactorEnabled,

--- a/packages/frontend/src/components/settings/WorkspaceSettingsSection.vue
+++ b/packages/frontend/src/components/settings/WorkspaceSettingsSection.vue
@@ -29,7 +29,8 @@
           <div class="flex items-center justify-between">
             <button
               type="submit"
-              class="px-4 py-2 bg-button text-button-text rounded-md shadow-sm hover:bg-button-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition duration-150 ease-in-out text-sm font-medium"
+              :disabled="popupEditorLoading"
+              class="px-4 py-2 bg-button text-button-text rounded-md shadow-sm hover:bg-button-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition duration-150 ease-in-out text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {{ $t('common.save') }}
             </button>
@@ -66,7 +67,8 @@
           <div class="flex items-center justify-between">
             <button
               type="submit"
-              class="px-4 py-2 bg-button text-button-text rounded-md shadow-sm hover:bg-button-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition duration-150 ease-in-out text-sm font-medium"
+              :disabled="showPopupFileManagerLoading"
+              class="px-4 py-2 bg-button text-button-text rounded-md shadow-sm hover:bg-button-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition duration-150 ease-in-out text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {{ t('common.save') }}
             </button>
@@ -105,7 +107,8 @@
           <div class="flex items-center justify-between">
             <button
               type="submit"
-              class="px-4 py-2 bg-button text-button-text rounded-md shadow-sm hover:bg-button-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition duration-150 ease-in-out text-sm font-medium"
+              :disabled="shareTabsLoading"
+              class="px-4 py-2 bg-button text-button-text rounded-md shadow-sm hover:bg-button-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition duration-150 ease-in-out text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {{ $t('common.save') }}
             </button>
@@ -141,7 +144,8 @@
           <div class="flex items-center justify-between">
             <button
               type="submit"
-              class="px-4 py-2 bg-button text-button-text rounded-md shadow-sm hover:bg-button-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition duration-150 ease-in-out text-sm font-medium"
+              :disabled="autoCopyLoading"
+              class="px-4 py-2 bg-button text-button-text rounded-md shadow-sm hover:bg-button-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition duration-150 ease-in-out text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {{ $t('common.save') }}
             </button>
@@ -180,7 +184,8 @@
           <div class="flex items-center justify-between">
             <button
               type="submit"
-              class="px-4 py-2 bg-button text-button-text rounded-md shadow-sm hover:bg-button-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition duration-150 ease-in-out text-sm font-medium"
+              :disabled="workspaceSidebarPersistentLoading"
+              class="px-4 py-2 bg-button text-button-text rounded-md shadow-sm hover:bg-button-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition duration-150 ease-in-out text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {{ $t('common.save') }}
             </button>
@@ -239,7 +244,8 @@
           <div class="flex items-center justify-between">
             <button
               type="submit"
-              class="px-4 py-2 bg-button text-button-text rounded-md shadow-sm hover:bg-button-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition duration-150 ease-in-out text-sm font-medium"
+              :disabled="commandInputSyncLoading"
+              class="px-4 py-2 bg-button text-button-text rounded-md shadow-sm hover:bg-button-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition duration-150 ease-in-out text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {{ $t('common.save') }}
             </button>
@@ -283,7 +289,8 @@
           <div class="flex items-center justify-between pt-2">
             <button
               type="submit"
-              class="px-4 py-2 bg-button text-button-text rounded-md shadow-sm hover:bg-button-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition duration-150 ease-in-out text-sm font-medium"
+              :disabled="showConnectionTagsLoading"
+              class="px-4 py-2 bg-button text-button-text rounded-md shadow-sm hover:bg-button-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition duration-150 ease-in-out text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {{ $t('common.save') }}
             </button>
@@ -329,7 +336,8 @@
           <div class="flex items-center justify-between pt-2">
             <button
               type="submit"
-              class="px-4 py-2 bg-button text-button-text rounded-md shadow-sm hover:bg-button-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition duration-150 ease-in-out text-sm font-medium"
+              :disabled="showQuickCommandTagsLoading"
+              class="px-4 py-2 bg-button text-button-text rounded-md shadow-sm hover:bg-button-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition duration-150 ease-in-out text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {{ $t('common.save') }}
             </button>
@@ -374,7 +382,8 @@
           <div class="flex items-center justify-between">
             <button
               type="submit"
-              class="px-4 py-2 bg-button text-button-text rounded-md shadow-sm hover:bg-button-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition duration-150 ease-in-out text-sm font-medium"
+              :disabled="terminalScrollbackLimitLoading"
+              class="px-4 py-2 bg-button text-button-text rounded-md shadow-sm hover:bg-button-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition duration-150 ease-in-out text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {{ t('common.save') }}
             </button>
@@ -501,7 +510,8 @@
           <div class="flex items-center justify-between pt-2">
             <button
               type="submit"
-              class="px-4 py-2 bg-button text-button-text rounded-md shadow-sm hover:bg-button-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition duration-150 ease-in-out text-sm font-medium"
+              :disabled="fileManagerShowDeleteConfirmationLoading"
+              class="px-4 py-2 bg-button text-button-text rounded-md shadow-sm hover:bg-button-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition duration-150 ease-in-out text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {{ $t('common.save') }}
             </button>
@@ -553,7 +563,8 @@
           <div class="flex items-center justify-between pt-2">
             <button
               type="submit"
-              class="px-4 py-2 bg-button text-button-text rounded-md shadow-sm hover:bg-button-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition duration-150 ease-in-out text-sm font-medium"
+              :disabled="fileManagerSingleClickOpenFileLoading"
+              class="px-4 py-2 bg-button text-button-text rounded-md shadow-sm hover:bg-button-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition duration-150 ease-in-out text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {{ $t('common.save') }}
             </button>
@@ -595,7 +606,8 @@
           <div class="flex items-center justify-between pt-2">
             <button
               type="submit"
-              class="px-4 py-2 bg-button text-button-text rounded-md shadow-sm hover:bg-button-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition duration-150 ease-in-out text-sm font-medium"
+              :disabled="terminalEnableRightClickPasteLoading"
+              class="px-4 py-2 bg-button text-button-text rounded-md shadow-sm hover:bg-button-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition duration-150 ease-in-out text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {{ $t('common.save') }}
             </button>
@@ -720,7 +732,8 @@
           <div class="flex items-center justify-between">
             <button
               type="submit"
-              class="px-4 py-2 bg-button text-button-text rounded-md shadow-sm hover:bg-button-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition duration-150 ease-in-out text-sm font-medium"
+              :disabled="statusMonitorLoading"
+              class="px-4 py-2 bg-button text-button-text rounded-md shadow-sm hover:bg-button-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition duration-150 ease-in-out text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {{ t('settings.statusMonitor.saveButton') }}
             </button>
@@ -775,7 +788,8 @@
           <div class="flex items-center justify-between">
             <button
               type="submit"
-              class="px-4 py-2 bg-button text-button-text rounded-md shadow-sm hover:bg-button-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition duration-150 ease-in-out text-sm font-medium"
+              :disabled="dockerSettingsLoading"
+              class="px-4 py-2 bg-button text-button-text rounded-md shadow-sm hover:bg-button-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition duration-150 ease-in-out text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {{ t('settings.docker.saveButton') }}
             </button>
@@ -808,34 +822,42 @@ const systemSettings = useSystemSettings();
 
 const {
   popupEditorEnabled,
+  popupEditorLoading,
   popupEditorMessage,
   popupEditorSuccess,
   handleUpdatePopupEditorSetting,
   shareTabsEnabled,
+  shareTabsLoading,
   shareTabsMessage,
   shareTabsSuccess,
   handleUpdateShareTabsSetting,
   autoCopyEnabled,
+  autoCopyLoading,
   autoCopyMessage,
   autoCopySuccess,
   handleUpdateAutoCopySetting,
   workspaceSidebarPersistentEnabled,
+  workspaceSidebarPersistentLoading,
   workspaceSidebarPersistentMessage,
   workspaceSidebarPersistentSuccess,
   handleUpdateWorkspaceSidebarSetting,
   commandInputSyncTargetLocal,
+  commandInputSyncLoading,
   commandInputSyncMessage,
   commandInputSyncSuccess,
   handleUpdateCommandInputSyncTarget,
   showConnectionTagsLocal,
+  showConnectionTagsLoading,
   showConnectionTagsMessage,
   showConnectionTagsSuccess,
   handleUpdateShowConnectionTags,
   showQuickCommandTagsLocal,
+  showQuickCommandTagsLoading,
   showQuickCommandTagsMessage,
   showQuickCommandTagsSuccess,
   handleUpdateShowQuickCommandTags,
   terminalScrollbackLimitLocal,
+  terminalScrollbackLimitLoading,
   terminalScrollbackLimitMessage,
   terminalScrollbackLimitSuccess,
   handleUpdateTerminalScrollbackLimit,
@@ -850,10 +872,12 @@ const {
   sshSuspendKeepAliveSecondsSuccess,
   handleUpdateSshSuspendKeepAliveSeconds,
   fileManagerShowDeleteConfirmationLocal,
+  fileManagerShowDeleteConfirmationLoading,
   fileManagerShowDeleteConfirmationMessage,
   fileManagerShowDeleteConfirmationSuccess,
   handleUpdateFileManagerDeleteConfirmation,
   fileManagerSingleClickOpenFileLocal,
+  fileManagerSingleClickOpenFileLoading,
   fileManagerSingleClickOpenFileMessage,
   fileManagerSingleClickOpenFileSuccess,
   handleUpdateFileManagerSingleClickOpenFile,
@@ -863,6 +887,7 @@ const {
   terminalEnableRightClickPasteSuccess,
   handleUpdateTerminalRightClickPasteSetting,
   showPopupFileManagerLocal,
+  showPopupFileManagerLoading,
   showPopupFileManagerMessage,
   showPopupFileManagerSuccess,
   handleUpdateShowPopupFileManager,
@@ -880,11 +905,13 @@ const {
 
 const {
   statusMonitorIntervalLocal,
+  statusMonitorLoading,
   statusMonitorMessage,
   statusMonitorSuccess,
   handleUpdateStatusMonitorInterval,
   dockerInterval,
   dockerExpandDefault,
+  dockerSettingsLoading,
   dockerSettingsMessage,
   dockerSettingsSuccess,
   handleUpdateDockerSettings,

--- a/packages/frontend/src/composables/settings/useIpBlacklist.ts
+++ b/packages/frontend/src/composables/settings/useIpBlacklist.ts
@@ -16,6 +16,7 @@ export function useIpBlacklist() {
 
   // --- IP Blacklist Enabled State & Method ---
   const ipBlacklistEnabled = ref(true); // Local state for the switch
+  const ipBlacklistToggleError = ref<string | null>(null);
 
   watch(
     ipBlacklistEnabledBoolean,
@@ -28,6 +29,7 @@ export function useIpBlacklist() {
   const handleUpdateIpBlacklistEnabled = async () => {
     const originalValue = ipBlacklistEnabled.value;
     const nextValue = !originalValue;
+    ipBlacklistToggleError.value = null;
     // 立即切换本地状态，失败时再回滚
     ipBlacklistEnabled.value = nextValue;
 
@@ -37,7 +39,10 @@ export function useIpBlacklist() {
     } catch (error: unknown) {
       log.error('更新 IP 黑名单启用状态失败:', error);
       ipBlacklistEnabled.value = originalValue; // Revert on failure
-      // Optionally, show an error message to the user
+      ipBlacklistToggleError.value = extractErrorMessage(
+        error,
+        t('settings.ipBlacklist.error.updateFailed', '更新 IP 黑名单启用状态失败')
+      );
     }
   };
 
@@ -153,13 +158,14 @@ export function useIpBlacklist() {
   });
 
   watch(ipBlacklistEnabled, (newValue) => {
-    if (newValue && ipBlacklist.entries.length === 0 && !ipBlacklist.loading) {
+    if (newValue && !ipBlacklist.loading) {
       fetchIpBlacklist();
     }
   });
 
   return {
     ipBlacklistEnabled,
+    ipBlacklistToggleError,
     handleUpdateIpBlacklistEnabled,
     blacklistSettingsForm,
     blacklistSettingsLoading,

--- a/packages/frontend/src/composables/settings/usePasskeyManagement.ts
+++ b/packages/frontend/src/composables/settings/usePasskeyManagement.ts
@@ -129,6 +129,7 @@ export function usePasskeyManagement() {
       await authStore.deletePasskey(credentialID);
       passkeyMessage.value = t('settings.passkey.success.deleted');
       passkeySuccess.value = true;
+      passkeyDeleteError.value = null;
       // authStore.fetchPasskeys() is usually called within deletePasskey in the store
     } catch (error: unknown) {
       log.error(`删除 Passkey ${credentialID} 失败:`, error);

--- a/packages/frontend/src/composables/settings/useSystemSettings.ts
+++ b/packages/frontend/src/composables/settings/useSystemSettings.ts
@@ -167,15 +167,12 @@ export function useSystemSettings() {
     settings,
     (newSettings) => {
       if (newSettings) {
-        selectedLanguage.value = newSettings.language || 'en-US'; // Default to en-US
         selectedTimezone.value = newSettings.timezone || 'UTC';
         statusMonitorIntervalLocal.value = parseInt(
           newSettings.statusMonitorIntervalSeconds || '3',
           10
         );
         dockerInterval.value = parseInt(newSettings.dockerStatusIntervalSeconds || '2', 10);
-        // dockerExpandDefault.value is already reactive from storeToRefs (dockerDefaultExpandBoolean)
-        // but we keep a local ref for the form v-model and sync it.
         dockerExpandDefault.value = newSettings.dockerDefaultExpand === 'true';
       }
     },

--- a/packages/frontend/src/composables/settings/useWorkspaceSettings.ts
+++ b/packages/frontend/src/composables/settings/useWorkspaceSettings.ts
@@ -45,6 +45,7 @@ export function useWorkspaceSettings() {
       popupEditorSuccess.value = true;
     } catch (error: unknown) {
       log.error('更新弹窗编辑器设置失败:', error);
+      popupEditorEnabled.value = showPopupFileEditorBoolean.value;
       popupEditorMessage.value = extractErrorMessage(
         error,
         t('settings.popupEditor.error.saveFailed')
@@ -72,6 +73,7 @@ export function useWorkspaceSettings() {
       shareTabsSuccess.value = true;
     } catch (error: unknown) {
       log.error('更新共享编辑器标签页设置失败:', error);
+      shareTabsEnabled.value = shareFileEditorTabsBoolean.value;
       shareTabsMessage.value = extractErrorMessage(
         error,
         t('settings.shareEditorTabs.error.saveFailed')
@@ -93,12 +95,12 @@ export function useWorkspaceSettings() {
     autoCopyMessage.value = '';
     autoCopySuccess.value = false;
     try {
-      const valueToSave = autoCopyEnabled.value ? 'true' : 'false';
-      await settingsStore.updateSetting('autoCopyOnSelect', valueToSave);
+      await settingsStore.updateSetting('autoCopyOnSelect', autoCopyEnabled.value);
       autoCopyMessage.value = t('settings.autoCopyOnSelect.success.saved');
       autoCopySuccess.value = true;
     } catch (error: unknown) {
       log.error('更新自动复制设置失败:', error);
+      autoCopyEnabled.value = autoCopyOnSelectBoolean.value;
       autoCopyMessage.value = extractErrorMessage(
         error,
         t('settings.autoCopyOnSelect.error.saveFailed')
@@ -128,6 +130,7 @@ export function useWorkspaceSettings() {
       workspaceSidebarPersistentSuccess.value = true;
     } catch (error: unknown) {
       log.error('更新侧边栏固定设置失败:', error);
+      workspaceSidebarPersistentEnabled.value = workspaceSidebarPersistentBoolean.value;
       workspaceSidebarPersistentMessage.value = extractErrorMessage(
         error,
         t('settings.workspace.error.sidebarPersistentSaveFailed')
@@ -363,6 +366,7 @@ export function useWorkspaceSettings() {
       fileManagerShowDeleteConfirmationSuccess.value = true;
     } catch (error: unknown) {
       log.error('更新文件管理器删除确认设置失败:', error);
+      fileManagerShowDeleteConfirmationLocal.value = fileManagerShowDeleteConfirmationBoolean.value;
       fileManagerShowDeleteConfirmationMessage.value = extractErrorMessage(
         error,
         t('settings.workspace.fileManagerDeleteConfirmError', '保存文件管理器删除确认设置失败。')
@@ -393,6 +397,7 @@ export function useWorkspaceSettings() {
       fileManagerSingleClickOpenFileSuccess.value = true;
     } catch (error: unknown) {
       log.error('更新文件管理器文件打开方式设置失败:', error);
+      fileManagerSingleClickOpenFileLocal.value = fileManagerSingleClickOpenFileBoolean.value;
       fileManagerSingleClickOpenFileMessage.value = extractErrorMessage(
         error,
         t(
@@ -426,6 +431,7 @@ export function useWorkspaceSettings() {
       terminalEnableRightClickPasteSuccess.value = true;
     } catch (error: unknown) {
       log.error('更新终端右键粘贴设置失败:', error);
+      terminalEnableRightClickPasteLocal.value = terminalEnableRightClickPasteBoolean.value;
       terminalEnableRightClickPasteMessage.value = extractErrorMessage(
         error,
         t('settings.workspace.terminalRightClickPasteError', '保存终端右键粘贴设置失败。')
@@ -453,6 +459,7 @@ export function useWorkspaceSettings() {
       showPopupFileManagerSuccess.value = true;
     } catch (error: unknown) {
       log.error('更新弹窗文件管理器设置失败:', error);
+      showPopupFileManagerLocal.value = showPopupFileManagerBoolean.value;
       showPopupFileManagerMessage.value = extractErrorMessage(
         error,
         t('settings.popupFileManager.error.saveFailed')

--- a/packages/frontend/src/stores/aiSettings.store.ts
+++ b/packages/frontend/src/stores/aiSettings.store.ts
@@ -57,9 +57,13 @@ export const useAISettingsStore = defineStore('aiSettings', () => {
   async function saveSettings(newSettings: AISettings): Promise<void> {
     isLoading.value = true;
     try {
-      const response = await apiClient.post('/ai/settings', newSettings);
+      const response = await apiClient.post<{
+        success: boolean;
+        settings?: AISettings;
+        message?: string;
+      }>('/ai/settings', newSettings);
       if (response.data.success) {
-        settings.value = newSettings;
+        settings.value = response.data.settings || newSettings;
       } else {
         throw new Error(response.data.message || '保存配置失败');
       }

--- a/packages/frontend/src/views/SettingsView.vue
+++ b/packages/frontend/src/views/SettingsView.vue
@@ -25,7 +25,7 @@
         </button>
       </div>
 
-      <!-- Error state (Show first if error exists) -->
+      <!-- Error state -->
       <div
         v-if="settingsError"
         class="p-4 mb-4 border-l-4 border-error bg-error/10 text-error rounded"
@@ -34,7 +34,7 @@
       </div>
 
       <!-- Settings Content based on activeTab -->
-      <div v-else class="space-y-6">
+      <div class="space-y-6">
         <!-- Non-blocking CAPTCHA load error (e.g., 429 rate limit) -->
         <div
           v-if="captchaError"
@@ -153,7 +153,6 @@ import { computed, onMounted, ref } from 'vue';
 import { useAuthStore } from '../stores/auth.store';
 import { useSettingsStore } from '../stores/settings.store';
 import { useCaptchaSettingsStore } from '../stores/captchaSettings.store';
-import { useAppearanceStore } from '../stores/appearance.store';
 import { useI18n } from 'vue-i18n';
 import { storeToRefs } from 'pinia';
 import { useVersionCheck } from '../composables/settings/useVersionCheck';
@@ -172,7 +171,6 @@ import AISettingsSection from '../components/settings/AISettingsSection.vue';
 
 const authStore = useAuthStore();
 const settingsStore = useSettingsStore();
-const appearanceStore = useAppearanceStore(); // 实例化外观 store
 const { t } = useI18n();
 const { isUpdateAvailable, checkLatestVersion } = useVersionCheck();
 


### PR DESCRIPTION
## Summary

- 修复 autoCopyOnSelect 走错 API 端点（字符串改为布尔值，命中专用 booleanEndpoints）
- 补全 12 个保存按钮的 disabled loading 状态防止重复提交
- 保存失败时回滚开关到 store 中的旧值，修复 UI 与后端状态不一致
- IP 黑名单开关失败时显示错误提示，重新启用时重新拉取列表
- Captcha secret key 留空时添加保留旧值提示，保存按钮显示加载文本
- AI 设置保存后使用后端返回值同步 store，delete 改为 undefined
- 移除死代码（未使用的 useI18n、appearanceStore 导入）
- SettingsView 错误时保留 tab 导航栏可见
- SystemSettings 语言回退值对齐 store getter，移除重复 watcher
- Passkey 删除成功后显式清除 deleteError
- debugMode 添加会话级设置提示说明

## Test plan

- [x] `vue-tsc --noEmit` 类型检查通过
- [x] 94 文件 / 2496 用例全部通过
- [x] ESLint + Prettier 通过
- [x] Codex 代码审查通过（修复了 Critical 回滚逻辑问题）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix settings page toggle desync and double submissions, with proper rollback on save failures. Improves error handling and keeps the UI in sync with backend values.

- Bug Fixes
  - Toggles: roll back to previous store value on save failure across workspace/file/terminal; show IP blacklist toggle errors and refetch the list when re-enabled.
  - Double submits: added disabled/loading states to 12 Save buttons; CAPTCHA Save shows “Saving...” text.
  - API correctness: `autoCopyOnSelect` now uses the boolean endpoint and sends a boolean.
  - AI settings: sync store with backend response after save; set `openaiEndpoint` to `undefined`; add a note that debug mode is session-scoped.
  - UX polish: keep Settings tabs visible when the page errors; add “leave blank to keep existing” hint for CAPTCHA secret key.
  - Cleanup/consistency: align system language fallback with the store; clear passkey `deleteError` after successful delete; remove unused `useI18n`/`appearanceStore` imports.

<sup>Written for commit fccf2f722698f429d51ba58227eead2f95b8405d. Summary will update on new commits. <a href="https://cubic.dev/pr/Silentely/nexus-terminal/pull/77?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

