### PR TITLE
✨ feat(terminal): webgl 终端渲染增强

### DIFF
--- a/packages/backend/src/appearance/appearance.repository.ts
+++ b/packages/backend/src/appearance/appearance.repository.ts
@@ -113,6 +113,12 @@ const mapRowsToAppearanceSettings = (rows: DbAppearanceSettingsRow[]): Appearanc
         settings.terminalTextShadowColor = row.value;
         terminalTextShadowColorFound = true;
         break;
+      case 'terminalRenderMode':
+        settings.terminalRenderMode = row.value;
+        break;
+      case 'terminalShowFps':
+        settings.terminalShowFps = row.value === 'true';
+        break;
     }
   }
 
@@ -194,6 +200,8 @@ const getDefaultAppearanceSettings = (): Omit<AppearanceSettings, '_id'> => {
     terminalTextShadowOffsetY: 2,
     terminalTextShadowBlur: 0,
     terminalTextShadowColor: '#000000',
+    terminalRenderMode: 'auto', // 默认渲染模式
+    terminalShowFps: false, // 默认关闭 FPS 显示
     updatedAt: Date.now(), // 提供默认时间戳
   };
 };
@@ -235,6 +243,8 @@ export const ensureDefaultSettingsExist = async (db: sqlite3.Database): Promise<
     { key: 'terminalTextShadowOffsetY', value: defaults.terminalTextShadowOffsetY },
     { key: 'terminalTextShadowBlur', value: defaults.terminalTextShadowBlur },
     { key: 'terminalTextShadowColor', value: defaults.terminalTextShadowColor },
+    { key: 'terminalRenderMode', value: defaults.terminalRenderMode },
+    { key: 'terminalShowFps', value: defaults.terminalShowFps },
   ];
 
   try {

--- a/packages/backend/src/settings/settings.repository.ts
+++ b/packages/backend/src/settings/settings.repository.ts
@@ -320,6 +320,8 @@ export const ensureDefaultSettingsExist = async (db: sqlite3.Database): Promise<
     terminalAutoWrapEnabled: 'true', // 终端自动换行默认启用
     sshSuspendKeepAliveSeconds: '0', // 挂起会话保活时长（秒），0 表示永久
     terminalEnableRightClickPaste: 'true', // 终端右键粘贴默认值
+    terminalRenderMode: 'auto', // 终端渲染模式（auto/webgl/canvas/dom）
+    terminalShowFps: 'false', // 是否显示 FPS（字符串布尔值）
   };
   const nowSeconds = Math.floor(Date.now() / 1000);
   const sqlInsertOrIgnore = `INSERT OR IGNORE INTO settings (key, value, created_at, updated_at) VALUES (?, ?, ?, ?)`;

--- a/packages/backend/src/types/appearance.types.ts
+++ b/packages/backend/src/types/appearance.types.ts
@@ -38,6 +38,8 @@ export interface AppearanceSettings {
   terminalTextShadowOffsetY?: number;
   terminalTextShadowBlur?: number;
   terminalTextShadowColor?: string;
+  terminalRenderMode?: string; // 终端渲染模式：auto/webgl/canvas/dom
+  terminalShowFps?: boolean; // 是否显示 FPS 监控
   updatedAt?: number;
 }
 

--- a/packages/frontend/src/composables/terminal/useTerminalRenderer.test.ts
+++ b/packages/frontend/src/composables/terminal/useTerminalRenderer.test.ts
@@ -1,0 +1,439 @@
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { ref } from 'vue';
+
+vi.mock('@/utils/log', () => ({
+  log: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// --- WebglAddon Mock ---
+
+let contextLossHandler: (() => void) | null = null;
+
+const mockDisposeWebgl = vi.fn();
+
+vi.mock('@xterm/addon-webgl', () => ({
+  WebglAddon: class {
+    dispose = mockDisposeWebgl;
+    onContextLoss(cb: () => void) {
+      contextLossHandler = cb;
+    }
+  },
+}));
+
+// --- requestAnimationFrame / cancelAnimationFrame Mock ---
+
+let rafCallback: ((ts: number) => void) | null = null;
+const mockRequestAnimationFrame = vi.fn((cb: (ts: number) => void) => {
+  rafCallback = cb;
+  return 1;
+});
+const mockCancelAnimationFrame = vi.fn();
+
+// --- performance.now Mock ---
+
+const mockPerformanceNow = vi.fn(() => 0);
+
+// --- Terminal Mock ---
+
+function makeTerminal(overrides: Record<string, unknown> = {}) {
+  return {
+    loadAddon: vi.fn(),
+    write: vi.fn(),
+    onData: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+    ...overrides,
+  };
+}
+
+describe('useTerminalRenderer', () => {
+  beforeAll(() => {
+    vi.stubGlobal('requestAnimationFrame', mockRequestAnimationFrame);
+    vi.stubGlobal('cancelAnimationFrame', mockCancelAnimationFrame);
+    vi.stubGlobal('performance', { now: mockPerformanceNow });
+  });
+
+  beforeEach(() => {
+    contextLossHandler = null;
+    rafCallback = null;
+    mockRequestAnimationFrame.mockClear();
+    mockCancelAnimationFrame.mockClear();
+    mockDisposeWebgl.mockClear();
+  });
+
+  // ========== 渲染模式管理 ==========
+
+  describe('渲染模式管理', () => {
+    it('默认模式为 auto', async () => {
+      const { useTerminalRenderer } = await import('./useTerminalRenderer');
+      const terminal = ref(makeTerminal() as any);
+      const { renderMode } = useTerminalRenderer(terminal, 's1');
+
+      expect(renderMode.value).toBe('auto');
+    });
+
+    it('默认活动渲染器为 dom', async () => {
+      const { useTerminalRenderer } = await import('./useTerminalRenderer');
+      const terminal = ref(makeTerminal() as any);
+      const { activeRenderer } = useTerminalRenderer(terminal, 's1');
+
+      expect(activeRenderer.value).toBe('dom');
+    });
+
+    it('setRenderMode 切换模式', async () => {
+      const { useTerminalRenderer } = await import('./useTerminalRenderer');
+      const terminal = ref(makeTerminal() as any);
+      const { renderMode, setRenderMode } = useTerminalRenderer(terminal, 's1');
+
+      setRenderMode('canvas');
+      expect(renderMode.value).toBe('canvas');
+    });
+
+    it('auto 模式优先加载 WebGL addon', async () => {
+      const { useTerminalRenderer } = await import('./useTerminalRenderer');
+      const term = makeTerminal();
+      const terminal = ref(term as any);
+      const { setRenderMode, activeRenderer } = useTerminalRenderer(terminal, 's1');
+
+      setRenderMode('auto');
+
+      expect(term.loadAddon).toHaveBeenCalled();
+      expect(activeRenderer.value).toBe('webgl');
+    });
+
+    it('auto 模式 WebGL 加载失败时降级为 canvas', async () => {
+      const { useTerminalRenderer } = await import('./useTerminalRenderer');
+      const term = makeTerminal({
+        loadAddon: vi.fn().mockImplementation(() => {
+          throw new Error('WebGL not supported');
+        }),
+      });
+      const terminal = ref(term as any);
+      const { initRenderer, activeRenderer, contextState } = useTerminalRenderer(terminal, 's1');
+
+      initRenderer();
+
+      expect(activeRenderer.value).toBe('canvas');
+      expect(contextState.value).toBe('unavailable');
+    });
+
+    it('canvas 模式不加载额外 addon', async () => {
+      const { useTerminalRenderer } = await import('./useTerminalRenderer');
+      const term = makeTerminal();
+      const terminal = ref(term as any);
+      const { setRenderMode, activeRenderer, contextState } = useTerminalRenderer(terminal, 's1');
+
+      setRenderMode('canvas');
+
+      expect(activeRenderer.value).toBe('canvas');
+      expect(contextState.value).toBe('unavailable');
+    });
+
+    it('dom 模式设置活动渲染器为 dom', async () => {
+      const { useTerminalRenderer } = await import('./useTerminalRenderer');
+      const term = makeTerminal();
+      const terminal = ref(term as any);
+      const { setRenderMode, activeRenderer, contextState } = useTerminalRenderer(terminal, 's1');
+
+      setRenderMode('dom');
+
+      expect(activeRenderer.value).toBe('dom');
+      expect(contextState.value).toBe('unavailable');
+    });
+
+    it('webgl 模式加载成功时设置活动渲染器为 webgl', async () => {
+      const { useTerminalRenderer } = await import('./useTerminalRenderer');
+      const term = makeTerminal();
+      const terminal = ref(term as any);
+      const { setRenderMode, activeRenderer, contextState } = useTerminalRenderer(terminal, 's1');
+
+      setRenderMode('webgl');
+
+      expect(activeRenderer.value).toBe('webgl');
+      expect(contextState.value).toBe('active');
+    });
+
+    it('webgl 模式加载失败时降级为 dom', async () => {
+      const { useTerminalRenderer } = await import('./useTerminalRenderer');
+      const term = makeTerminal({
+        loadAddon: vi.fn().mockImplementation(() => {
+          throw new Error('WebGL not supported');
+        }),
+      });
+      const terminal = ref(term as any);
+      const { setRenderMode, activeRenderer, contextState } = useTerminalRenderer(terminal, 's1');
+
+      setRenderMode('webgl');
+
+      expect(activeRenderer.value).toBe('dom');
+      expect(contextState.value).toBe('unavailable');
+    });
+
+    it('terminal 为 null 时 setRenderMode 不应报错', async () => {
+      const { useTerminalRenderer } = await import('./useTerminalRenderer');
+      const terminal = ref(null);
+      const { setRenderMode, renderMode } = useTerminalRenderer(terminal, 's1');
+
+      setRenderMode('canvas');
+      expect(renderMode.value).toBe('canvas');
+    });
+
+    it('切换模式时先卸载旧 addon', async () => {
+      const { useTerminalRenderer } = await import('./useTerminalRenderer');
+      const term = makeTerminal();
+      const terminal = ref(term as any);
+      const { setRenderMode } = useTerminalRenderer(terminal, 's1');
+
+      // 先加载 WebGL addon
+      setRenderMode('webgl');
+      mockDisposeWebgl.mockClear();
+
+      // 切换到 canvas 模式，应先卸载 WebGL addon
+      setRenderMode('canvas');
+      expect(mockDisposeWebgl).toHaveBeenCalled();
+    });
+  });
+
+  // ========== FPS 采样 ==========
+
+  describe('FPS 采样', () => {
+    it('startMonitoring 启动 RAF 采样', async () => {
+      const { useTerminalRenderer } = await import('./useTerminalRenderer');
+      const terminal = ref(makeTerminal() as any);
+      const { startMonitoring } = useTerminalRenderer(terminal, 's1');
+
+      startMonitoring();
+
+      expect(mockRequestAnimationFrame).toHaveBeenCalled();
+    });
+
+    it('stopMonitoring 停止采样', async () => {
+      const { useTerminalRenderer } = await import('./useTerminalRenderer');
+      const terminal = ref(makeTerminal() as any);
+      const { startMonitoring, stopMonitoring } = useTerminalRenderer(terminal, 's1');
+
+      startMonitoring();
+      stopMonitoring();
+
+      expect(mockCancelAnimationFrame).toHaveBeenCalled();
+    });
+
+    it('FPS 值在合理范围内', async () => {
+      const { useTerminalRenderer } = await import('./useTerminalRenderer');
+      const terminal = ref(makeTerminal() as any);
+      const { startMonitoring, stopMonitoring, fps, getMetrics } = useTerminalRenderer(
+        terminal,
+        's1'
+      );
+
+      // 验证初始 FPS 为 0
+      expect(fps.value).toBe(0);
+
+      // 启动监控后 FPS 仍为 0（需等待采样窗口）
+      startMonitoring();
+      expect(fps.value).toBe(0);
+
+      // 停止监控
+      stopMonitoring();
+      expect(mockCancelAnimationFrame).toHaveBeenCalled();
+
+      // 验证 getMetrics 返回的 fps 字段类型正确
+      const metrics = getMetrics();
+      expect(typeof metrics.fps).toBe('number');
+      expect(metrics.fps).toBeGreaterThanOrEqual(0);
+    });
+
+    it('重复调用 startMonitoring 不应重复启动', async () => {
+      const { useTerminalRenderer } = await import('./useTerminalRenderer');
+      const terminal = ref(makeTerminal() as any);
+      const { startMonitoring } = useTerminalRenderer(terminal, 's1');
+
+      startMonitoring();
+      mockRequestAnimationFrame.mockClear();
+      startMonitoring();
+
+      expect(mockRequestAnimationFrame).not.toHaveBeenCalled();
+    });
+
+    it('未启动监控时 sampleFrame 不应执行', async () => {
+      const { useTerminalRenderer } = await import('./useTerminalRenderer');
+      const terminal = ref(makeTerminal() as any);
+      const { fps } = useTerminalRenderer(terminal, 's1');
+
+      // 直接调用 raf 回调（未启动监控）
+      rafCallback?.(100);
+
+      expect(fps.value).toBe(0);
+    });
+  });
+
+  // ========== Context Loss ==========
+
+  describe('Context Loss', () => {
+    it('context loss 后记录次数', async () => {
+      const { useTerminalRenderer } = await import('./useTerminalRenderer');
+      const term = makeTerminal();
+      const terminal = ref(term as any);
+      const { setRenderMode, contextLossCount } = useTerminalRenderer(terminal, 's1');
+
+      setRenderMode('webgl');
+      expect(contextLossCount.value).toBe(0);
+
+      // 触发 context loss
+      contextLossHandler?.();
+
+      expect(contextLossCount.value).toBe(1);
+    });
+
+    it('auto 模式 context loss 后降级为 dom', async () => {
+      const { useTerminalRenderer } = await import('./useTerminalRenderer');
+      const term = makeTerminal();
+      const terminal = ref(term as any);
+      const { setRenderMode, activeRenderer, contextState } = useTerminalRenderer(terminal, 's1');
+
+      setRenderMode('auto');
+      expect(activeRenderer.value).toBe('webgl');
+      expect(contextState.value).toBe('active');
+
+      // 触发 context loss
+      contextLossHandler?.();
+
+      expect(contextState.value).toBe('lost');
+      expect(activeRenderer.value).toBe('dom');
+    });
+
+    it('webgl 模式 context loss 后尝试恢复', async () => {
+      const { useTerminalRenderer } = await import('./useTerminalRenderer');
+      const term = makeTerminal();
+      const terminal = ref(term as any);
+      const { setRenderMode, activeRenderer, contextState } = useTerminalRenderer(terminal, 's1');
+
+      setRenderMode('webgl');
+      expect(activeRenderer.value).toBe('webgl');
+
+      // 触发 context loss
+      contextLossHandler?.();
+
+      // 恢复成功，重新加载了 addon
+      expect(activeRenderer.value).toBe('webgl');
+      expect(contextState.value).toBe('active');
+    });
+
+    it('webgl 模式恢复失败后降级为 dom', async () => {
+      const { useTerminalRenderer } = await import('./useTerminalRenderer');
+      const term = makeTerminal({
+        loadAddon: vi.fn().mockImplementation(() => {
+          throw new Error('fail');
+        }),
+      });
+      const terminal = ref(term as any);
+      const { setRenderMode, activeRenderer, contextState } = useTerminalRenderer(terminal, 's1');
+
+      setRenderMode('webgl');
+
+      // 触发 context loss（此时 loadAddon 会抛异常）
+      contextLossHandler?.();
+
+      expect(activeRenderer.value).toBe('dom');
+    });
+  });
+
+  // ========== getMetrics ==========
+
+  describe('getMetrics', () => {
+    it('返回完整的 RenderMetrics 对象', async () => {
+      const { useTerminalRenderer } = await import('./useTerminalRenderer');
+      const terminal = ref(makeTerminal() as any);
+      const {
+        getMetrics,
+        renderMode,
+        activeRenderer,
+        fps,
+        frameTime,
+        contextState,
+        contextLossCount,
+      } = useTerminalRenderer(terminal, 's1');
+
+      const metrics = getMetrics();
+
+      expect(metrics).toEqual({
+        renderMode: renderMode.value,
+        activeRenderer: activeRenderer.value,
+        fps: fps.value,
+        frameTime: frameTime.value,
+        contextState: contextState.value,
+        contextLossCount: contextLossCount.value,
+      });
+    });
+
+    it('渲染模式切换后 getMetrics 反映最新状态', async () => {
+      const { useTerminalRenderer } = await import('./useTerminalRenderer');
+      const term = makeTerminal();
+      const terminal = ref(term as any);
+      const { setRenderMode, getMetrics } = useTerminalRenderer(terminal, 's1');
+
+      setRenderMode('canvas');
+      const metrics = getMetrics();
+
+      expect(metrics.renderMode).toBe('canvas');
+      expect(metrics.activeRenderer).toBe('canvas');
+    });
+  });
+
+  // ========== cleanup ==========
+
+  describe('cleanup', () => {
+    it('cleanup 应停止监控并卸载 addon', async () => {
+      const { useTerminalRenderer } = await import('./useTerminalRenderer');
+      const terminal = ref(makeTerminal() as any);
+      const { setRenderMode, startMonitoring, cleanup } = useTerminalRenderer(terminal, 's1');
+
+      // 先加载 WebGL addon
+      setRenderMode('webgl');
+      mockDisposeWebgl.mockClear();
+      startMonitoring();
+
+      cleanup();
+
+      expect(mockCancelAnimationFrame).toHaveBeenCalled();
+      expect(mockDisposeWebgl).toHaveBeenCalled();
+    });
+
+    it('cleanup 后 contextState 为 unavailable', async () => {
+      const { useTerminalRenderer } = await import('./useTerminalRenderer');
+      const terminal = ref(makeTerminal() as any);
+      const { cleanup, contextState } = useTerminalRenderer(terminal, 's1');
+
+      cleanup();
+
+      expect(contextState.value).toBe('unavailable');
+    });
+  });
+
+  // ========== initRenderer ==========
+
+  describe('initRenderer', () => {
+    it('terminal 为 null 时 initRenderer 不应报错', async () => {
+      const { useTerminalRenderer } = await import('./useTerminalRenderer');
+      const terminal = ref(null);
+      const { initRenderer } = useTerminalRenderer(terminal, 's1');
+
+      initRenderer();
+    });
+
+    it('initRenderer 应根据当前模式加载渲染器', async () => {
+      const { useTerminalRenderer } = await import('./useTerminalRenderer');
+      const term = makeTerminal();
+      const terminal = ref(term as any);
+      const { initRenderer } = useTerminalRenderer(terminal, 's1');
+
+      initRenderer();
+
+      // 默认 auto 模式，应尝试加载 WebGL
+      expect(term.loadAddon).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/frontend/src/composables/terminal/useTerminalRenderer.test.ts
+++ b/packages/frontend/src/composables/terminal/useTerminalRenderer.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
 import { ref } from 'vue';
 
 vi.mock('@/utils/log', () => ({
@@ -49,7 +49,7 @@ function makeTerminal(overrides: Record<string, unknown> = {}) {
   };
 }
 
-describe('useTerminalRenderer', () => {
+describe('useTerminalRenderer 渲染器管理', () => {
   beforeAll(() => {
     vi.stubGlobal('requestAnimationFrame', mockRequestAnimationFrame);
     vi.stubGlobal('cancelAnimationFrame', mockCancelAnimationFrame);
@@ -272,7 +272,7 @@ describe('useTerminalRenderer', () => {
 
   // ========== Context Loss ==========
 
-  describe('Context Loss', () => {
+  describe('上下文丢失处理', () => {
     it('context loss 后记录次数', async () => {
       const { useTerminalRenderer } = await import('./useTerminalRenderer');
       const term = makeTerminal();
@@ -322,28 +322,37 @@ describe('useTerminalRenderer', () => {
       expect(contextState.value).toBe('active');
     });
 
-    it('webgl 模式恢复失败后降级为 dom', async () => {
+    it('webgl 模式 context loss 后恢复失败时降级为 dom', async () => {
       const { useTerminalRenderer } = await import('./useTerminalRenderer');
-      const term = makeTerminal({
-        loadAddon: vi.fn().mockImplementation(() => {
+      // 首次加载成功，恢复时失败
+      const loadAddon = vi
+        .fn()
+        .mockImplementationOnce(() => {
+          // 初次加载成功
+        })
+        .mockImplementationOnce(() => {
+          // context loss 后恢复失败
           throw new Error('fail');
-        }),
-      });
+        });
+      const term = makeTerminal({ loadAddon });
       const terminal = ref(term as any);
       const { setRenderMode, activeRenderer, contextState } = useTerminalRenderer(terminal, 's1');
 
       setRenderMode('webgl');
+      expect(activeRenderer.value).toBe('webgl');
 
-      // 触发 context loss（此时 loadAddon 会抛异常）
+      // 触发 context loss（恢复时 loadAddon 会抛异常）
       contextLossHandler?.();
 
+      expect(loadAddon).toHaveBeenCalledTimes(2);
       expect(activeRenderer.value).toBe('dom');
+      expect(contextState.value).toBe('unavailable');
     });
   });
 
   // ========== getMetrics ==========
 
-  describe('getMetrics', () => {
+  describe('性能指标获取', () => {
     it('返回完整的 RenderMetrics 对象', async () => {
       const { useTerminalRenderer } = await import('./useTerminalRenderer');
       const terminal = ref(makeTerminal() as any);
@@ -385,7 +394,7 @@ describe('useTerminalRenderer', () => {
 
   // ========== cleanup ==========
 
-  describe('cleanup', () => {
+  describe('清理与资源释放', () => {
     it('cleanup 应停止监控并卸载 addon', async () => {
       const { useTerminalRenderer } = await import('./useTerminalRenderer');
       const terminal = ref(makeTerminal() as any);
@@ -415,7 +424,7 @@ describe('useTerminalRenderer', () => {
 
   // ========== initRenderer ==========
 
-  describe('initRenderer', () => {
+  describe('渲染器初始化', () => {
     it('terminal 为 null 时 initRenderer 不应报错', async () => {
       const { useTerminalRenderer } = await import('./useTerminalRenderer');
       const terminal = ref(null);

--- a/packages/frontend/src/composables/terminal/useTerminalRenderer.ts
+++ b/packages/frontend/src/composables/terminal/useTerminalRenderer.ts
@@ -142,13 +142,13 @@ export function useTerminalRenderer(terminal: Ref<Terminal | null>, sessionId: s
           recoveryAttempts = 0;
           activeRenderer.value = 'webgl';
         } else {
-          // 恢复失败，记录状态但不降级（webgl 强制模式）
+          // 恢复失败，降级为 DOM 渲染器
           activeRenderer.value = 'dom';
+          contextState.value = 'unavailable';
           if (recoveryAttempts >= MAX_WEBGL_RECOVERY_ATTEMPTS) {
             log.warn(
-              `[Terminal ${sessionId}] WebGL 恢复已达最大次数 ${MAX_WEBGL_RECOVERY_ATTEMPTS}，渲染器降级为 DOM`
+              `[Terminal ${sessionId}] WebGL 恢复已达最大次数 ${MAX_WEBGL_RECOVERY_ATTEMPTS}，渲染器永久降级为 DOM`
             );
-            contextState.value = 'unavailable';
           }
         }
       }

--- a/packages/frontend/src/composables/terminal/useTerminalRenderer.ts
+++ b/packages/frontend/src/composables/terminal/useTerminalRenderer.ts
@@ -1,0 +1,344 @@
+/**
+ * useTerminalRenderer composable
+ * 封装终端渲染器管理，包括 WebGL/Canvas/DOM 渲染模式切换、
+ * FPS 采样监控与 WebGL 上下文丢失恢复
+ */
+
+import { ref, onBeforeUnmount, type Ref } from 'vue';
+import type { Terminal } from '@xterm/xterm';
+import { WebglAddon } from '@xterm/addon-webgl';
+import { log } from '@/utils/log';
+
+// 渲染模式类型
+export type RenderMode = 'auto' | 'webgl' | 'canvas' | 'dom';
+
+// WebGL 上下文状态
+export type ContextState = 'active' | 'lost' | 'unavailable';
+
+// 渲染性能指标
+export interface RenderMetrics {
+  /** 当前配置的渲染模式 */
+  renderMode: RenderMode;
+  /** 实际生效的渲染器类型 */
+  activeRenderer: 'webgl' | 'canvas' | 'dom';
+  /** 当前 FPS（每 60 帧更新一次） */
+  fps: number;
+  /** 最近 60 帧的平均帧时间（毫秒） */
+  frameTime: number;
+  /** WebGL 上下文状态 */
+  contextState: ContextState;
+  /** 上下文丢失累计次数 */
+  contextLossCount: number;
+}
+
+// WebGL 模式下最大自动恢复尝试次数
+const MAX_WEBGL_RECOVERY_ATTEMPTS = 3;
+
+// FPS 采样窗口大小（帧数）
+const FPS_SAMPLE_SIZE = 60;
+
+export function useTerminalRenderer(terminal: Ref<Terminal | null>, sessionId: string) {
+  // --- 响应式状态 ---
+
+  /** 当前配置的渲染模式 */
+  const renderMode = ref<RenderMode>('auto');
+
+  /** 实际生效的渲染器类型 */
+  const activeRenderer = ref<'webgl' | 'canvas' | 'dom'>('dom');
+
+  /** WebGL 上下文状态 */
+  const contextState = ref<ContextState>('unavailable');
+
+  /** 上下文丢失累计次数 */
+  const contextLossCount = ref(0);
+
+  /** 当前 FPS 值 */
+  const fps = ref(0);
+
+  /** 最近 60 帧的平均帧时间（毫秒） */
+  const frameTime = ref(0);
+
+  // --- 内部状态 ---
+
+  let webglAddonInstance: WebglAddon | null = null;
+  let rafId: number | null = null;
+  let lastFrameTime = 0;
+  let frameCount = 0;
+  let frameTimeAccumulator = 0;
+  let isMonitoring = false;
+  /** WebGL 强制模式下的恢复尝试计数 */
+  let recoveryAttempts = 0;
+
+  // --- 渲染器 Addon 生命周期管理 ---
+
+  /**
+   * 卸载当前 WebGL addon，清理引用与事件监听
+   */
+  function disposeWebglAddon(): void {
+    if (webglAddonInstance) {
+      try {
+        webglAddonInstance.dispose();
+      } catch {
+        // dispose 过程中可能抛出异常，静默忽略
+      }
+      webglAddonInstance = null;
+    }
+  }
+
+  /**
+   * 加载 WebGL addon 并注册上下文丢失监听
+   * @returns 是否加载成功
+   */
+  function loadWebglAddon(term: Terminal): boolean {
+    try {
+      const addon = new WebglAddon();
+      addon.onContextLoss(() => {
+        log.warn(`[Terminal ${sessionId}] WebGL 上下文丢失`);
+        contextState.value = 'lost';
+        contextLossCount.value++;
+        if (webglAddonInstance) {
+          try {
+            webglAddonInstance.dispose();
+          } catch {
+            // 忽略 dispose 错误
+          }
+          webglAddonInstance = null;
+        }
+        // 根据当前渲染模式决定恢复策略
+        handleContextLossRecovery(term);
+      });
+      term.loadAddon(addon);
+      webglAddonInstance = addon;
+      contextState.value = 'active';
+      log.info(`[Terminal ${sessionId}] WebGL 渲染器已加载`);
+      return true;
+    } catch (error: unknown) {
+      log.warn(`[Terminal ${sessionId}] WebGL addon 加载失败，降级渲染：`, error);
+      webglAddonInstance = null;
+      contextState.value = 'unavailable';
+      return false;
+    }
+  }
+
+  /**
+   * 根据当前渲染模式处理 WebGL 上下文丢失后的恢复逻辑
+   * - auto 模式：降级为 DOM 渲染器
+   * - webgl 模式：尝试重新加载（最多 MAX_WEBGL_RECOVERY_ATTEMPTS 次）
+   */
+  function handleContextLossRecovery(term: Terminal): void {
+    if (renderMode.value === 'auto') {
+      // auto 模式：降级为 DOM 渲染器，不再尝试恢复
+      activeRenderer.value = 'dom';
+      log.info(`[Terminal ${sessionId}] auto 模式：WebGL 上下文丢失后降级为 DOM 渲染器`);
+    } else if (renderMode.value === 'webgl') {
+      // webgl 强制模式：尝试重新加载
+      if (recoveryAttempts < MAX_WEBGL_RECOVERY_ATTEMPTS) {
+        recoveryAttempts++;
+        log.info(
+          `[Terminal ${sessionId}] WebGL 恢复尝试 ${recoveryAttempts}/${MAX_WEBGL_RECOVERY_ATTEMPTS}`
+        );
+        const success = loadWebglAddon(term);
+        if (success) {
+          recoveryAttempts = 0;
+          activeRenderer.value = 'webgl';
+        } else {
+          // 恢复失败，记录状态但不降级（webgl 强制模式）
+          activeRenderer.value = 'dom';
+          if (recoveryAttempts >= MAX_WEBGL_RECOVERY_ATTEMPTS) {
+            log.warn(
+              `[Terminal ${sessionId}] WebGL 恢复已达最大次数 ${MAX_WEBGL_RECOVERY_ATTEMPTS}，渲染器降级为 DOM`
+            );
+            contextState.value = 'unavailable';
+          }
+        }
+      }
+    }
+    // canvas/dom 模式下不涉及 WebGL，无需处理
+  }
+
+  /**
+   * 根据渲染模式加载对应的 addon
+   * 模式切换流程：卸载旧 addon → 加载新 addon
+   */
+  function applyRendererMode(term: Terminal): void {
+    // 先卸载现有 WebGL addon
+    disposeWebglAddon();
+
+    switch (renderMode.value) {
+      case 'webgl': {
+        const success = loadWebglAddon(term);
+        if (success) {
+          activeRenderer.value = 'webgl';
+          recoveryAttempts = 0;
+        } else {
+          // webgl 强制模式但加载失败，降级为 DOM
+          activeRenderer.value = 'dom';
+          contextState.value = 'unavailable';
+        }
+        break;
+      }
+      case 'auto': {
+        // auto 模式：优先尝试 WebGL
+        const success = loadWebglAddon(term);
+        if (success) {
+          activeRenderer.value = 'webgl';
+        } else {
+          // WebGL 不可用，xterm 默认使用 canvas 渲染器
+          activeRenderer.value = 'canvas';
+          contextState.value = 'unavailable';
+        }
+        break;
+      }
+      case 'canvas': {
+        // canvas 模式：xterm 默认渲染器，无需额外 addon
+        activeRenderer.value = 'canvas';
+        contextState.value = 'unavailable';
+        log.info(`[Terminal ${sessionId}] 切换为 canvas 渲染器`);
+        break;
+      }
+      case 'dom': {
+        // DOM 模式：使用 xterm 内置 DOM 渲染器
+        activeRenderer.value = 'dom';
+        contextState.value = 'unavailable';
+        log.info(`[Terminal ${sessionId}] 切换为 DOM 渲染器`);
+        break;
+      }
+    }
+  }
+
+  /**
+   * 设置渲染模式并应用
+   * @param mode 目标渲染模式
+   */
+  function setRenderMode(mode: RenderMode): void {
+    renderMode.value = mode;
+    const term = terminal.value;
+    if (!term) return;
+    applyRendererMode(term);
+  }
+
+  // --- FPS 采样监控（基于 requestAnimationFrame）---
+
+  /**
+   * 单帧采样回调
+   * 每 60 帧计算一次 FPS 和平均帧时间
+   */
+  function sampleFrame(timestamp: number): void {
+    if (!isMonitoring) return;
+
+    if (lastFrameTime > 0) {
+      const delta = timestamp - lastFrameTime;
+      frameTimeAccumulator += delta;
+      frameCount++;
+    }
+    lastFrameTime = timestamp;
+
+    // 每 60 帧更新一次 FPS 值
+    if (frameCount >= FPS_SAMPLE_SIZE) {
+      const avgFrameTime = frameTimeAccumulator / frameCount;
+      frameTime.value = Math.round(avgFrameTime * 100) / 100;
+      fps.value = avgFrameTime > 0 ? Math.round(1000 / avgFrameTime) : 0;
+      // 重置采样窗口
+      frameCount = 0;
+      frameTimeAccumulator = 0;
+    }
+
+    rafId = requestAnimationFrame(sampleFrame);
+  }
+
+  /**
+   * 启动 FPS 监控
+   * 使用 requestAnimationFrame 采样，不创建额外定时器
+   */
+  function startMonitoring(): void {
+    if (isMonitoring) return;
+    isMonitoring = true;
+    lastFrameTime = 0;
+    frameCount = 0;
+    frameTimeAccumulator = 0;
+    rafId = requestAnimationFrame(sampleFrame);
+    log.debug(`[Terminal ${sessionId}] FPS 监控已启动`);
+  }
+
+  /**
+   * 停止 FPS 监控
+   */
+  function stopMonitoring(): void {
+    isMonitoring = false;
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+    log.debug(`[Terminal ${sessionId}] FPS 监控已停止`);
+  }
+
+  // --- 性能指标查询 ---
+
+  /**
+   * 获取完整的渲染性能指标
+   */
+  function getMetrics(): RenderMetrics {
+    return {
+      renderMode: renderMode.value,
+      activeRenderer: activeRenderer.value,
+      fps: fps.value,
+      frameTime: frameTime.value,
+      contextState: contextState.value,
+      contextLossCount: contextLossCount.value,
+    };
+  }
+
+  // --- 初始化与清理 ---
+
+  /**
+   * 初始化渲染器：在 terminal 打开后调用
+   * 根据当前 renderMode 加载对应的渲染 addon
+   */
+  function initRenderer(): void {
+    const term = terminal.value;
+    if (!term) return;
+    applyRendererMode(term);
+  }
+
+  /**
+   * 清理所有资源
+   * 在组件卸载或 terminal 销毁时调用
+   */
+  function cleanup(): void {
+    stopMonitoring();
+    disposeWebglAddon();
+    contextState.value = 'unavailable';
+  }
+
+  onBeforeUnmount(() => {
+    cleanup();
+  });
+
+  return {
+    /** 当前配置的渲染模式 */
+    renderMode,
+    /** 实际生效的渲染器类型 */
+    activeRenderer,
+    /** WebGL 上下文状态 */
+    contextState,
+    /** 上下文丢失累计次数 */
+    contextLossCount,
+    /** 当前 FPS 值 */
+    fps,
+    /** 最近 60 帧的平均帧时间（毫秒） */
+    frameTime,
+
+    /** 设置渲染模式并应用 */
+    setRenderMode,
+    /** 初始化渲染器（terminal 打开后调用） */
+    initRenderer,
+    /** 启动 FPS 监控 */
+    startMonitoring,
+    /** 停止 FPS 监控 */
+    stopMonitoring,
+    /** 获取完整渲染性能指标 */
+    getMetrics,
+    /** 清理所有资源 */
+    cleanup,
+  };
+}

--- a/packages/frontend/src/features/terminal/Terminal.test.ts
+++ b/packages/frontend/src/features/terminal/Terminal.test.ts
@@ -113,6 +113,8 @@ const {
     terminalTextShadowBlur: { value: 0, __v_isRef: true as const },
     terminalTextShadowColor: { value: '#000', __v_isRef: true as const },
     initialAppearanceDataLoaded: { value: true, __v_isRef: true as const },
+    currentRenderMode: { value: 'auto', __v_isRef: true as const },
+    isFpsEnabled: { value: false, __v_isRef: true as const },
   },
   mockSettingsState: {
     autoCopyOnSelectBoolean: { value: false, __v_isRef: true as const },
@@ -139,6 +141,32 @@ vi.mock('../../composables/terminal/useTerminalFit', () => ({
     fitAndEmitResizeNow: mockFitAndEmitResizeNow,
     setupResizeObserver: mockSetupResizeObserver,
   }),
+}));
+
+vi.mock('../../composables/terminal/useTerminalRenderer', () => ({
+  useTerminalRenderer: () => ({
+    renderMode: { value: 'auto', __v_isRef: true as const },
+    fps: { value: 0, __v_isRef: true as const },
+    contextState: { value: 'active', __v_isRef: true as const },
+    contextLossCount: { value: 0, __v_isRef: true as const },
+    frameTime: { value: 0, __v_isRef: true as const },
+    setRenderMode: vi.fn(),
+    initRenderer: vi.fn(),
+    startMonitoring: vi.fn(),
+    stopMonitoring: vi.fn(),
+    getMetrics: vi.fn().mockReturnValue({
+      renderMode: 'auto',
+      activeRenderer: 'webgl',
+      fps: 0,
+      frameTime: 0,
+      contextState: 'active',
+      contextLossCount: 0,
+    }),
+  }),
+}));
+
+vi.mock('./components/PerformanceMonitor.vue', () => ({
+  default: { name: 'PerformanceMonitor', template: '<div />' },
 }));
 
 vi.mock('../../composables/terminal/useTerminalSocket', () => ({

--- a/packages/frontend/src/features/terminal/Terminal.vue
+++ b/packages/frontend/src/features/terminal/Terminal.vue
@@ -18,7 +18,6 @@ import { useSessionStore } from '../../stores/session.store';
 import { storeToRefs } from 'pinia';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import { SearchAddon, type ISearchOptions } from '@xterm/addon-search';
-import { WebglAddon } from '@xterm/addon-webgl';
 import '@xterm/xterm/css/xterm.css';
 import {
   useWorkspaceEventEmitter,
@@ -35,7 +34,9 @@ const { t } = useI18n();
 // Import extracted composables
 import { useTerminalFit } from '../../composables/terminal/useTerminalFit';
 import { useTerminalSocket } from '../../composables/terminal/useTerminalSocket';
+import { useTerminalRenderer } from '../../composables/terminal/useTerminalRenderer';
 import { OutputEnhancerAddon } from './addons/output-enhancer';
+import PerformanceMonitor from './components/PerformanceMonitor.vue';
 import { log } from '@/utils/log';
 
 // 定义 props 和 emits
@@ -57,7 +58,6 @@ const textareaKeydownHandler = ref<((event: KeyboardEvent) => void) | null>(null
 let searchAddon: SearchAddon | null = null;
 let outputEnhancerAddon: OutputEnhancerAddon | null = null;
 let selectionListenerDisposable: IDisposable | null = null;
-let webglAddonInstance: WebglAddon | null = null; // 保存 WebGL addon 引用以便检查状态
 
 const isActiveRef = ref(props.isActive);
 watch(
@@ -87,6 +87,14 @@ const { fitAddon, fitAndEmitResizeNow, setupResizeObserver } = useTerminalFit(
 
 const { setupInputHandler } = useTerminalSocket(terminalInstance, props.sessionId, streamRef);
 
+const { contextState, setRenderMode, initRenderer, startMonitoring, stopMonitoring, getMetrics } =
+  useTerminalRenderer(terminalInstance, props.sessionId);
+
+// 性能监控面板显示状态 — 由 appearance store 的 isFpsEnabled 驱动
+const togglePerformanceMonitor = () => {
+  appearanceStore.toggleFps();
+};
+
 let initialPinchDistance = 0;
 let currentFontSizeOnPinchStart = 0;
 
@@ -105,6 +113,8 @@ const {
   terminalTextShadowBlur,
   terminalTextShadowColor,
   initialAppearanceDataLoaded,
+  currentRenderMode,
+  isFpsEnabled,
 } = storeToRefs(appearanceStore);
 
 const isTerminalDomReady = ref(false);
@@ -373,27 +383,12 @@ onMounted(() => {
       outputEnhancerAddon = null; // 降级：不使用输出增强功能
     }
 
-    try {
-      webglAddonInstance = new WebglAddon();
-      webglAddonInstance.onContextLoss(() => {
-        log.warn(`[Terminal ${props.sessionId}] WebGL context lost. Falling back to DOM renderer.`);
-        if (webglAddonInstance) {
-          webglAddonInstance.dispose();
-          webglAddonInstance = null; // 清除引用，标记上下文已丢失
-        }
-      });
-      term.loadAddon(webglAddonInstance);
-      log.info(`[Terminal ${props.sessionId}] WebGL renderer enabled.`);
-    } catch (error: unknown) {
-      log.warn(
-        `[Terminal ${props.sessionId}] WebGL addon failed to load, falling back to canvas/dom renderer:`,
-        error
-      );
-      webglAddonInstance = null;
-    }
+    // 使用 composable 初始化渲染器（自动选择 WebGL/Canvas/DOM）
+    initRenderer();
 
     term.open(terminalRef.value);
     isTerminalDomReady.value = true;
+    startMonitoring(); // 启动 FPS 采样监控
     log.info(`[Terminal ${props.sessionId}] Xterm open() called.`);
 
     applyTerminalWrapMode();
@@ -446,11 +441,11 @@ onMounted(() => {
             term.options.theme = newTheme;
             // 只有当 WebGL 渲染器可用且上下文未丢失时才手动刷新
             // 否则让 xterm 自己处理重绘（Canvas/DOM 渲染器）
-            if (webglAddonInstance) {
-              // WebGL 渲染器存在，使用 nextTick 延迟刷新以确保状态稳定
+            if (contextState.value === 'active') {
+              // WebGL 渲染器活跃，使用 nextTick 延迟刷新以确保状态稳定
               nextTick(() => {
                 try {
-                  if (term && webglAddonInstance) {
+                  if (term && contextState.value === 'active') {
                     term.refresh(0, term.rows - 1);
                   }
                 } catch (refreshError: unknown) {
@@ -458,15 +453,6 @@ onMounted(() => {
                     `[Terminal ${props.sessionId}] WebGL refresh failed, WebGL context may be lost:`,
                     refreshError
                   );
-                  // WebGL 上下文可能已丢失，清理引用
-                  if (webglAddonInstance) {
-                    try {
-                      webglAddonInstance.dispose();
-                    } catch {
-                      // 忽略 dispose 错误
-                    }
-                    webglAddonInstance = null;
-                  }
                 }
               });
             }
@@ -563,6 +549,12 @@ onMounted(() => {
       applyTerminalWrapMode();
     });
 
+    // --- 渲染模式响应：外观设置变化时切换渲染器 ---
+    watch(currentRenderMode, (newMode) => {
+      setRenderMode(newMode);
+      log.info(`[Terminal ${props.sessionId}] 渲染模式已切换为: ${newMode}`);
+    });
+
     // --- Wheel Zoom ---
     if (terminalRef.value) {
       terminalRef.value.addEventListener('wheel', handleWheelZoom);
@@ -579,15 +571,8 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
-  // 先清理 WebGL addon（在 terminal dispose 之前）
-  if (webglAddonInstance) {
-    try {
-      webglAddonInstance.dispose();
-    } catch {
-      // 忽略 dispose 错误
-    }
-    webglAddonInstance = null;
-  }
+  // 停止 FPS 监控（composable 内部也会通过 onBeforeUnmount 清理 WebGL addon）
+  stopMonitoring();
 
   // 清理 textarea keydown 监听器（dispose 前执行，因为 dispose 后 textarea 引用丢失）
   if (textareaKeydownHandler.value && terminalInstance.value?.textarea) {
@@ -720,6 +705,7 @@ watchEffect(() => {
     aria-live="polite"
   >
     <div ref="terminalRef" class="terminal-inner-container"></div>
+    <PerformanceMonitor :metrics="getMetrics()" :visible="isFpsEnabled" />
   </div>
 </template>
 

--- a/packages/frontend/src/features/terminal/Terminal.vue
+++ b/packages/frontend/src/features/terminal/Terminal.vue
@@ -388,7 +388,10 @@ onMounted(() => {
 
     term.open(terminalRef.value);
     isTerminalDomReady.value = true;
-    startMonitoring(); // 启动 FPS 采样监控
+    // 仅在用户启用 FPS 显示时启动采样，避免无用 RAF 循环
+    if (isFpsEnabled.value) {
+      startMonitoring();
+    }
     log.info(`[Terminal ${props.sessionId}] Xterm open() called.`);
 
     applyTerminalWrapMode();
@@ -553,6 +556,15 @@ onMounted(() => {
     watch(currentRenderMode, (newMode) => {
       setRenderMode(newMode);
       log.info(`[Terminal ${props.sessionId}] 渲染模式已切换为: ${newMode}`);
+    });
+
+    // --- FPS 监控响应：设置变化时启停采样 ---
+    watch(isFpsEnabled, (enabled) => {
+      if (enabled) {
+        startMonitoring();
+      } else {
+        stopMonitoring();
+      }
     });
 
     // --- Wheel Zoom ---

--- a/packages/frontend/src/features/terminal/components/PerformanceMonitor.vue
+++ b/packages/frontend/src/features/terminal/components/PerformanceMonitor.vue
@@ -47,6 +47,8 @@ const contextDotColor = computed(() => {
       return 'bg-yellow-400';
     case 'unavailable':
       return 'bg-red-400';
+    default:
+      return 'bg-gray-400';
   }
 });
 </script>

--- a/packages/frontend/src/features/terminal/components/PerformanceMonitor.vue
+++ b/packages/frontend/src/features/terminal/components/PerformanceMonitor.vue
@@ -1,0 +1,112 @@
+<script setup lang="ts">
+/**
+ * PerformanceMonitor 组件
+ * 半透明悬浮面板，实时展示终端渲染性能指标
+ * 包括：渲染模式、FPS、帧耗时、WebGL 上下文状态与丢失次数
+ */
+
+import { computed } from 'vue';
+import type { RenderMetrics } from '../../../composables/terminal/useTerminalRenderer';
+
+const props = defineProps<{
+  /** 渲染性能指标 */
+  metrics: RenderMetrics;
+  /** 是否显示面板 */
+  visible: boolean;
+}>();
+
+/** 渲染模式标签映射 */
+const renderModeLabel: Record<string, string> = {
+  auto: '自动',
+  webgl: 'WebGL',
+  canvas: 'Canvas',
+  dom: 'DOM',
+};
+
+/** 上下文状态标签映射 */
+const contextStateLabel: Record<string, string> = {
+  active: 'Active',
+  lost: 'Lost',
+  unavailable: 'Unavailable',
+};
+
+/** 根据 FPS 值返回对应颜色类 */
+const fpsColorClass = computed(() => {
+  const fps = props.metrics.fps;
+  if (fps > 50) return 'text-green-400';
+  if (fps >= 30) return 'text-yellow-400';
+  return 'text-red-400';
+});
+
+/** 上下文状态对应的指示颜色 */
+const contextDotColor = computed(() => {
+  switch (props.metrics.contextState) {
+    case 'active':
+      return 'bg-green-400';
+    case 'lost':
+      return 'bg-yellow-400';
+    case 'unavailable':
+      return 'bg-red-400';
+  }
+});
+</script>
+
+<template>
+  <Transition name="fade">
+    <div
+      v-if="visible"
+      class="absolute top-2 right-2 z-10 rounded-md bg-black/70 px-3 py-2 font-mono text-xs leading-relaxed text-gray-300 backdrop-blur-sm select-none pointer-events-none"
+    >
+      <!-- 渲染模式 -->
+      <div class="flex items-center gap-2">
+        <span class="text-gray-500">渲染:</span>
+        <span class="text-white">{{
+          renderModeLabel[metrics.renderMode] ?? metrics.renderMode
+        }}</span>
+        <span class="text-gray-600">({{ metrics.activeRenderer.toUpperCase() }})</span>
+      </div>
+
+      <!-- FPS -->
+      <div class="flex items-center gap-2">
+        <span class="text-gray-500">FPS:</span>
+        <span :class="fpsColorClass" class="font-semibold">{{ metrics.fps }}</span>
+      </div>
+
+      <!-- 帧耗时 -->
+      <div class="flex items-center gap-2">
+        <span class="text-gray-500">帧耗时:</span>
+        <span class="text-white">{{ metrics.frameTime }}ms</span>
+      </div>
+
+      <!-- WebGL 上下文状态 -->
+      <div class="flex items-center gap-2">
+        <span class="text-gray-500">GPU:</span>
+        <span class="inline-flex items-center gap-1.5">
+          <span :class="contextDotColor" class="inline-block h-1.5 w-1.5 rounded-full"></span>
+          <span class="text-white">{{
+            contextStateLabel[metrics.contextState] ?? metrics.contextState
+          }}</span>
+        </span>
+      </div>
+
+      <!-- Context Loss 次数（仅 >0 时显示） -->
+      <div v-if="metrics.contextLossCount > 0" class="flex items-center gap-2">
+        <span class="text-gray-500">丢失:</span>
+        <span class="text-red-400 font-semibold">{{ metrics.contextLossCount }}</span>
+      </div>
+    </div>
+  </Transition>
+</template>
+
+<style scoped>
+/* 面板淡入淡出过渡动画 */
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/packages/frontend/src/stores/appearance.store.ts
+++ b/packages/frontend/src/stores/appearance.store.ts
@@ -123,8 +123,8 @@ export const useAppearanceStore = defineStore('appearance', () => {
       } else if (settings.terminalRenderMode) {
         log.warn('[AppearanceStore] 非法渲染模式值，回退到 auto:', settings.terminalRenderMode);
       }
-      if (typeof settings.terminalShowFps === 'boolean') {
-        terminalShowFps.value = settings.terminalShowFps;
+      if (settings.terminalShowFps !== undefined) {
+        terminalShowFps.value = String(settings.terminalShowFps) === 'true';
       }
 
       // 初始化远程预设 URL

--- a/packages/frontend/src/stores/appearance.store.ts
+++ b/packages/frontend/src/stores/appearance.store.ts
@@ -24,6 +24,9 @@ import { createBackgroundStore, safeJsonParse } from './appearance-background.st
 import { createHtmlPresetsStore } from './appearance-html-presets.store';
 import { log } from '@/utils/log';
 
+// 终端渲染模式类型（内联定义，避免循环依赖）
+export type RenderMode = 'auto' | 'webgl' | 'canvas' | 'dom';
+
 // 重新导出 safeJsonParse 供外部使用（如 StyleCustomizerUiTab.vue）
 export { safeJsonParse };
 
@@ -37,6 +40,10 @@ export const useAppearanceStore = defineStore('appearance', () => {
   const appearanceSettings = ref<Partial<AppearanceSettings>>({});
   const initialAppearanceDataLoaded = ref(false);
   const allTerminalThemes = ref<TerminalTheme[]>([]);
+
+  // --- 渲染与性能状态 ---
+  const terminalRenderMode = ref<RenderMode>('auto');
+  const terminalShowFps = ref(false);
 
   // --- 内部 updateAppearanceSettings（供子 Store 调用） ---
   async function _updateAppearanceSettings(updates: Record<string, unknown>) {
@@ -88,6 +95,14 @@ export const useAppearanceStore = defineStore('appearance', () => {
     return typeof size === 'number' && size > 0 ? size : 14;
   });
 
+  // --- 渲染模式与 FPS ---
+  const VALID_RENDER_MODES: RenderMode[] = ['auto', 'webgl', 'canvas', 'dom'];
+  const isRenderMode = (value: unknown): value is RenderMode =>
+    typeof value === 'string' && VALID_RENDER_MODES.includes(value as RenderMode);
+
+  const currentRenderMode = computed<RenderMode>(() => terminalRenderMode.value);
+  const isFpsEnabled = computed<boolean>(() => terminalShowFps.value);
+
   // --- 核心 Action: 加载所有外观数据 ---
   async function loadInitialAppearanceData() {
     isLoading.value = true;
@@ -100,6 +115,17 @@ export const useAppearanceStore = defineStore('appearance', () => {
       appearanceSettings.value = settingsResponse.data;
       allTerminalThemes.value = themesResponse.data;
       initialAppearanceDataLoaded.value = true;
+
+      // 从后端加载渲染模式与 FPS 设置（带白名单校验）
+      const settings = settingsResponse.data;
+      if (isRenderMode(settings.terminalRenderMode)) {
+        terminalRenderMode.value = settings.terminalRenderMode;
+      } else if (settings.terminalRenderMode) {
+        log.warn('[AppearanceStore] 非法渲染模式值，回退到 auto:', settings.terminalRenderMode);
+      }
+      if (typeof settings.terminalShowFps === 'boolean') {
+        terminalShowFps.value = settings.terminalShowFps;
+      }
 
       // 初始化远程预设 URL
       htmlPresetsStore.initRemoteUrl();
@@ -128,6 +154,36 @@ export const useAppearanceStore = defineStore('appearance', () => {
     } catch (err: unknown) {
       log.error('更新外观设置失败:', err);
       throw new Error(extractErrorMessage(err, '更新外观设置失败'));
+    }
+  }
+
+  // --- 渲染模式 Action ---
+  async function setRenderMode(mode: RenderMode) {
+    const prevMode = terminalRenderMode.value;
+    terminalRenderMode.value = mode;
+    try {
+      await updateAppearanceSettings({ terminalRenderMode: mode } as UpdateAppearanceDto);
+      log.info('[AppearanceStore] 终端渲染模式已切换:', mode);
+    } catch (err: unknown) {
+      // 回滚本地状态
+      terminalRenderMode.value = prevMode;
+      log.error('[AppearanceStore] 渲染模式切换失败，已回滚:', err);
+    }
+  }
+
+  // --- FPS 显示 Action ---
+  async function toggleFps() {
+    const prevValue = terminalShowFps.value;
+    terminalShowFps.value = !terminalShowFps.value;
+    try {
+      await updateAppearanceSettings({
+        terminalShowFps: terminalShowFps.value,
+      } as UpdateAppearanceDto);
+      log.info('[AppearanceStore] FPS 显示已切换:', terminalShowFps.value);
+    } catch (err: unknown) {
+      // 回滚本地状态
+      terminalShowFps.value = prevValue;
+      log.error('[AppearanceStore] FPS 显示切换失败，已回滚:', err);
     }
   }
 
@@ -160,6 +216,12 @@ export const useAppearanceStore = defineStore('appearance', () => {
     loadInitialAppearanceData,
     updateAppearanceSettings,
     toggleStyleCustomizer,
+
+    // 渲染模式与 FPS
+    currentRenderMode,
+    isFpsEnabled,
+    setRenderMode,
+    toggleFps,
 
     // 终端主题（来自 themeStore）
     isPreviewingTerminalTheme: themeStore.isPreviewingTerminalTheme,

--- a/packages/frontend/src/types/appearance.types.ts
+++ b/packages/frontend/src/types/appearance.types.ts
@@ -30,6 +30,10 @@ export interface AppearanceSettings {
   terminalTextShadowOffsetY?: number;
   terminalTextShadowBlur?: number;
   terminalTextShadowColor?: string;
+
+  // 渲染模式与性能
+  terminalRenderMode?: 'auto' | 'webgl' | 'canvas' | 'dom';
+  terminalShowFps?: boolean;
 }
 
 // 前端用于更新外观设置的数据结构 (对应 API 请求体)


### PR DESCRIPTION
## Summary

- 新增 `useTerminalRenderer` composable，封装 WebGL/Canvas/DOM addon 生命周期管理
- 支持 `auto`/`webgl`/`canvas`/`dom` 四种渲染模式切换，auto 模式自动降级
- RAF 采样 FPS 实时监控，帧耗时统计
- WebGL context loss 自动检测与恢复（webgl 模式最多重试 3 次）
- 新增 `PerformanceMonitor` 悬浮面板，展示渲染模式、FPS、GPU context 状态
- appearance store 新增 `renderMode`/`showFps` 状态，与后端 settings 同步
- 后端 settings 新增 `terminalRenderMode`/`terminalShowFps` 默认值
- 新增 26 个单元测试，覆盖模式切换、FPS 采样、context loss 恢复

## Test plan

- [x] vue-tsc 类型检查通过
- [x] 2519 个前端测试全部通过（95 个测试文件）
- [x] 26 个新增单元测试覆盖核心逻辑
- [ ] 手动验证：渲染模式切换（auto → webgl → canvas → dom）
- [ ] 手动验证：FPS 显示开关
- [ ] 手动验证：性能面板展示
- [ ] 手动验证：WebGL context loss 后自动恢复

## 变更文件

| 文件 | 操作 | 说明 |
|------|------|------|
| `useTerminalRenderer.ts` | 新建 | 渲染器管理 composable |
| `useTerminalRenderer.test.ts` | 新建 | 26 个单元测试 |
| `PerformanceMonitor.vue` | 新建 | 性能监控面板 |
| `Terminal.vue` | 修改 | 集成 composable |
| `appearance.store.ts` | 修改 | 新增 renderMode/showFps |
| `appearance.types.ts` | 修改 | 新增类型字段 |
| `settings.repository.ts` | 修改 | 新增默认设置 |

## Summary by Sourcery

Introduce a configurable terminal renderer with performance monitoring and persistent appearance settings.

New Features:
- Add a useTerminalRenderer composable to manage WebGL/Canvas/DOM terminal renderers with FPS sampling and context loss handling.
- Add a PerformanceMonitor overlay component to display terminal render mode, FPS, frame timing, and GPU context status.
- Expose terminal rendering mode and FPS visibility as user settings synchronized with backend defaults.

Enhancements:
- Refactor Terminal.vue to delegate renderer lifecycle and monitoring to the new useTerminalRenderer composable and hook it up to appearance store state.

Tests:
- Add a comprehensive test suite for useTerminalRenderer covering render mode switching, FPS sampling behavior, context loss recovery, and cleanup handling.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a terminal renderer manager with WebGL/Canvas/DOM modes, auto fallback, and live FPS metrics. Introduces a floating performance panel and persists render settings; fixes FPS gating and WebGL recovery edge cases.

- **New Features**
  - `useTerminalRenderer` manages addon lifecycle and switches between `auto`/`webgl`/`canvas`/`dom`.
  - RAF-based FPS and frame-time sampling; WebGL context loss detection with auto-recovery (up to 3 retries).
  - `PerformanceMonitor` overlay shows mode, FPS, frame time, and GPU context; toggled via appearance.
  - `appearance.store` and backend add `terminalRenderMode` and `terminalShowFps` with defaults and validation; `Terminal.vue` integrates and adds 26 unit tests.

- **Bug Fixes**
  - Gate FPS sampling by `isFpsEnabled` to avoid idle `requestAnimationFrame` loops.
  - Normalize `terminalShowFps` string/boolean handling across frontend and backend.
  - On WebGL recovery failure, set `contextState` to `unavailable` and downgrade consistently.
  - Complete DB mappings/defaults for `terminalRenderMode`/`terminalShowFps` in appearance/settings; update tests and mocks.

<sup>Written for commit bce3cca286298a165649b61a6a95455647bf0a85. Summary will update on new commits. <a href="https://cubic.dev/pr/Silentely/nexus-terminal/pull/83?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

