### PR TITLE
✨ feat(frontend): 移动端触摸手势、WebGPU 渲染、WebCodecs 视频解码

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,15 @@
 
 本页面记录 Nexus Terminal 的重要版本更新和变更。
 
+## [Unreleased]
+
+### 改进
+
+- 🎨 WebGPU 渲染支持（`useWebGPURenderer`）：新增 WebGPU 能力检测与 GPUDevice 管理，作为最高优先级渲染模式，不可用时自动降级到 WebGL/Canvas/DOM
+- 🎨 WebCodecs 视频解码（`useVideoDecoder`）：新增基于 WebCodecs API 的硬件加速视频解码 composable，支持 OffscreenCanvas 离屏渲染，移动端/低端设备条件启用
+- 📱 终端触摸手势增强（`useTouchGestures`）：单指长按 500ms 弹出复制/粘贴/全选快捷菜单，单指上下滑动精准控制终端滚动
+- 📱 RDP/VNC 触摸-鼠标映射（`useTouchMouseMapping`）：支持 Absolute（直接映射坐标）和 Relative（触控板模式）两种模式，单指 tap=左键、长按=右键、双指 tap=右键、拖拽=鼠标拖拽
+
 ## v1.5.4（2026-06-05）
 
 ### 修复

--- a/packages/frontend/src/components/RemoteDesktopModal.vue
+++ b/packages/frontend/src/components/RemoteDesktopModal.vue
@@ -10,9 +10,13 @@ import { ConnectionInfo } from '../stores/connections.store';
 import { extractErrorMessage } from '../utils/errorExtractor';
 import { log } from '@/utils/log';
 import { useWebRTCTunnel } from '@/composables/useWebRTCTunnel';
+import { useVideoDecoder } from '@/composables/useVideoDecoder';
+import { useDeviceDetection } from '@/composables/useDeviceDetection';
+import { useTouchMouseMapping } from '@/composables/useTouchMouseMapping';
 
 const { t } = useI18n();
 const settingsStore = useSettingsStore();
+const { isMobile } = useDeviceDetection();
 
 const props = defineProps<{
   connection: ConnectionInfo | null;
@@ -30,6 +34,7 @@ const maxAllowedHeight = computed(() => window.innerHeight - MODAL_CONTAINER_PAD
 
 const rdpDisplayRef = ref<HTMLDivElement | null>(null);
 const rdpContainerRef = ref<HTMLDivElement | null>(null);
+const rdpTouchDisplayEl = ref<HTMLElement | null>(null);
 const guacClient = ref<InstanceType<typeof Guacamole.Client> | null>(null);
 const connectionStatus = ref<'disconnected' | 'connecting' | 'connected' | 'error'>('disconnected');
 const isResizing = ref(false);
@@ -40,11 +45,14 @@ const initialModalHeightForResize = ref(0);
 const statusMessage = ref('');
 const keyboard = ref<InstanceType<typeof Guacamole.Keyboard> | null>(null);
 const mouse = ref<InstanceType<typeof Guacamole.Mouse> | null>(null);
+let touchMouseMapping: ReturnType<typeof useTouchMouseMapping> | null = null;
 const desiredModalWidth = ref(1064);
 const desiredModalHeight = ref(858);
 
 const tempInputWidth = ref<number | string>(desiredModalWidth.value);
 const tempInputHeight = ref<number | string>(desiredModalHeight.value);
+const videoDecoderCanvas = ref<HTMLCanvasElement | null>(null);
+const videoDecoder = useVideoDecoder({ canvas: videoDecoderCanvas });
 
 const isKeyboardDisabledForInput = ref(false); // 标记键盘是否因输入框聚焦而禁用
 const isMinimized = ref(false);
@@ -63,9 +71,55 @@ interface GuacamoleStatus {
   message?: string;
 }
 
+interface NavigatorWithDeviceMemory extends Navigator {
+  deviceMemory?: number;
+}
+
 // 统一使用当前页面地址构建 WebSocket URL，本地开发时 Vite 代理会转发到后端
 const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
 const backendBaseUrl = `${wsProtocol}//${window.location.host}/ws`;
+
+/**
+ * 判断是否属于低端设备
+ * 使用浏览器暴露的核心数和内存信息做保守判断，缺失信息时不误判为低端设备。
+ */
+const isLowEndDevice = computed<boolean>(() => {
+  const hardwareConcurrency = navigator.hardwareConcurrency || 0;
+  const deviceMemory = (navigator as NavigatorWithDeviceMemory).deviceMemory || 0;
+  return (
+    (hardwareConcurrency > 0 && hardwareConcurrency <= 4) || (deviceMemory > 0 && deviceMemory <= 4)
+  );
+});
+
+/**
+ * 在远程桌面 canvas 可用后按需初始化 WebCodecs 解码器
+ * 当前 Guacamole 仍负责实际画面渲染，这里只完成移动端/低端设备的视频解码能力准备。
+ */
+async function initVideoDecoderIfNeeded(): Promise<void> {
+  if (!isMobile.value && !isLowEndDevice.value) {
+    videoDecoder.dispose();
+    log.info('[RemoteDesktopModal] 非移动端或低端设备，跳过 WebCodecs 初始化');
+    return;
+  }
+
+  await nextTick();
+
+  const displayCanvas = rdpDisplayRef.value?.querySelector('canvas') || null;
+  if (!displayCanvas) {
+    log.warn('[RemoteDesktopModal] 未找到远程桌面 canvas，跳过 WebCodecs 初始化');
+    return;
+  }
+
+  const decoderCanvas = document.createElement('canvas');
+  // 使用独立辅助 canvas 初始化解码器，避免抢占 Guacamole 正在使用的显示 canvas。
+  decoderCanvas.width = displayCanvas.width || displayCanvas.clientWidth || 1;
+  decoderCanvas.height = displayCanvas.height || displayCanvas.clientHeight || 1;
+  videoDecoderCanvas.value = decoderCanvas;
+  const initialized = await videoDecoder.init();
+  log.info(
+    `[RemoteDesktopModal] WebCodecs supported=${videoDecoder.isSupported.value}, offscreen=${videoDecoder.isUsingOffscreen.value}, initialized=${initialized}`
+  );
+}
 
 const handleConnection = async () => {
   if (!props.connection || !rdpDisplayRef.value) {
@@ -185,6 +239,7 @@ const handleConnection = async () => {
                 canvases.forEach((canvas) => {
                   canvas.style.zIndex = '999';
                 });
+                void initVideoDecoderIfNeeded();
               }
             });
           }, 100);
@@ -315,6 +370,19 @@ const setupInputListeners = () => {
           }
         };
 
+    if (isMobile.value) {
+      touchMouseMapping?.detach();
+      rdpTouchDisplayEl.value = displayEl;
+      // 移动端使用原生 Touch 事件映射 Guacamole 鼠标状态。
+      touchMouseMapping = useTouchMouseMapping({
+        guacClient,
+        displayEl: rdpTouchDisplayEl,
+        Guacamole,
+        initialMode: 'absolute',
+      });
+      touchMouseMapping.attach();
+    }
+
     keyboard.value = new Guacamole.Keyboard(displayEl); // 将监听器附加到 RDP 显示元素
 
     keyboard.value.onkeydown = (keysym: number) => {
@@ -361,6 +429,10 @@ const setupInputListeners = () => {
 };
 
 const removeInputListeners = () => {
+  touchMouseMapping?.detach();
+  touchMouseMapping = null;
+  rdpTouchDisplayEl.value = null;
+
   // 恢复光标并尝试移除监听器
   if (guacClient.value) {
     try {
@@ -463,6 +535,8 @@ const handleClickRestoreButton = () => {
 };
 
 const disconnectGuacamole = () => {
+  videoDecoder.dispose();
+  videoDecoderCanvas.value = null;
   removeInputListeners();
   isKeyboardDisabledForInput.value = false; // 确保状态重置
   if (guacClient.value) {

--- a/packages/frontend/src/components/RemoteDesktopModal.vue
+++ b/packages/frontend/src/components/RemoteDesktopModal.vue
@@ -45,7 +45,12 @@ const initialModalHeightForResize = ref(0);
 const statusMessage = ref('');
 const keyboard = ref<InstanceType<typeof Guacamole.Keyboard> | null>(null);
 const mouse = ref<InstanceType<typeof Guacamole.Mouse> | null>(null);
-let touchMouseMapping: ReturnType<typeof useTouchMouseMapping> | null = null;
+const touchMouseMapping = useTouchMouseMapping({
+  guacClient,
+  displayEl: rdpTouchDisplayEl,
+  Guacamole,
+  initialMode: 'absolute',
+});
 const desiredModalWidth = ref(1064);
 const desiredModalHeight = ref(858);
 
@@ -371,15 +376,8 @@ const setupInputListeners = () => {
         };
 
     if (isMobile.value) {
-      touchMouseMapping?.detach();
       rdpTouchDisplayEl.value = displayEl;
       // 移动端使用原生 Touch 事件映射 Guacamole 鼠标状态。
-      touchMouseMapping = useTouchMouseMapping({
-        guacClient,
-        displayEl: rdpTouchDisplayEl,
-        Guacamole,
-        initialMode: 'absolute',
-      });
       touchMouseMapping.attach();
     }
 
@@ -429,8 +427,7 @@ const setupInputListeners = () => {
 };
 
 const removeInputListeners = () => {
-  touchMouseMapping?.detach();
-  touchMouseMapping = null;
+  touchMouseMapping.detach();
   rdpTouchDisplayEl.value = null;
 
   // 恢复光标并尝试移除监听器

--- a/packages/frontend/src/components/VncModal.vue
+++ b/packages/frontend/src/components/VncModal.vue
@@ -101,7 +101,12 @@ const sendInputTextToVnc = async () => {
 };
 const keyboard = ref<InstanceType<typeof Guacamole.Keyboard> | null>(null);
 const mouse = ref<InstanceType<typeof Guacamole.Mouse> | null>(null);
-let touchMouseMapping: ReturnType<typeof useTouchMouseMapping> | null = null;
+const touchMouseMapping = useTouchMouseMapping({
+  guacClient,
+  displayEl: vncTouchDisplayEl,
+  Guacamole,
+  initialMode: 'absolute',
+});
 // Initialize desiredModalWidth and desiredModalHeight from store or defaults
 const initialStoreWidth = settingsStore.settings.vncModalWidth
   ? parseInt(settingsStore.settings.vncModalWidth, 10)
@@ -373,15 +378,8 @@ const setupInputListeners = () => {
         };
 
     if (isMobile.value) {
-      touchMouseMapping?.detach();
       vncTouchDisplayEl.value = displayEl;
       // 移动端使用原生 Touch 事件映射 Guacamole 鼠标状态。
-      touchMouseMapping = useTouchMouseMapping({
-        guacClient,
-        displayEl: vncTouchDisplayEl,
-        Guacamole,
-        initialMode: 'absolute',
-      });
       touchMouseMapping.attach();
     }
 
@@ -409,8 +407,7 @@ const setupInputListeners = () => {
 };
 
 const removeInputListeners = () => {
-  touchMouseMapping?.detach();
-  touchMouseMapping = null;
+  touchMouseMapping.detach();
   vncTouchDisplayEl.value = null;
 
   // Remove host copy event listener

--- a/packages/frontend/src/components/VncModal.vue
+++ b/packages/frontend/src/components/VncModal.vue
@@ -9,9 +9,12 @@ import type { ConnectionInfo } from '../stores/connections.store';
 import { extractErrorMessage } from '../utils/errorExtractor';
 import { log } from '@/utils/log';
 import { useWebRTCTunnel } from '@/composables/useWebRTCTunnel';
+import { useDeviceDetection } from '@/composables/useDeviceDetection';
+import { useTouchMouseMapping } from '@/composables/useTouchMouseMapping';
 
 const { t } = useI18n();
 const settingsStore = useSettingsStore();
+const { isMobile } = useDeviceDetection();
 
 const props = defineProps<{
   connection: ConnectionInfo | null;
@@ -29,6 +32,7 @@ const maxAllowedHeight = computed(() => window.innerHeight - MODAL_CONTAINER_PAD
 
 const vncDisplayRef = ref<HTMLDivElement | null>(null);
 const vncContainerRef = ref<HTMLDivElement | null>(null);
+const vncTouchDisplayEl = ref<HTMLElement | null>(null);
 const guacClient = ref<InstanceType<typeof Guacamole.Client> | null>(null);
 const connectionStatus = ref<'disconnected' | 'connecting' | 'connected' | 'error'>('disconnected');
 const isResizing = ref(false);
@@ -97,6 +101,7 @@ const sendInputTextToVnc = async () => {
 };
 const keyboard = ref<InstanceType<typeof Guacamole.Keyboard> | null>(null);
 const mouse = ref<InstanceType<typeof Guacamole.Mouse> | null>(null);
+let touchMouseMapping: ReturnType<typeof useTouchMouseMapping> | null = null;
 // Initialize desiredModalWidth and desiredModalHeight from store or defaults
 const initialStoreWidth = settingsStore.settings.vncModalWidth
   ? parseInt(settingsStore.settings.vncModalWidth, 10)
@@ -367,6 +372,19 @@ const setupInputListeners = () => {
           }
         };
 
+    if (isMobile.value) {
+      touchMouseMapping?.detach();
+      vncTouchDisplayEl.value = displayEl;
+      // 移动端使用原生 Touch 事件映射 Guacamole 鼠标状态。
+      touchMouseMapping = useTouchMouseMapping({
+        guacClient,
+        displayEl: vncTouchDisplayEl,
+        Guacamole,
+        initialMode: 'absolute',
+      });
+      touchMouseMapping.attach();
+    }
+
     keyboard.value = new Guacamole.Keyboard(displayEl);
 
     keyboard.value.onkeydown = (keysym: number) => {
@@ -391,6 +409,10 @@ const setupInputListeners = () => {
 };
 
 const removeInputListeners = () => {
+  touchMouseMapping?.detach();
+  touchMouseMapping = null;
+  vncTouchDisplayEl.value = null;
+
   // Remove host copy event listener
   // document.removeEventListener('copy', handleHostCopy); // Removed this
   if (guacClient.value) {

--- a/packages/frontend/src/composables/terminal/useTerminalRenderer.ts
+++ b/packages/frontend/src/composables/terminal/useTerminalRenderer.ts
@@ -9,9 +9,10 @@ import type { Terminal } from '@xterm/xterm';
 import { WebglAddon } from '@xterm/addon-webgl';
 import { Unicode11Addon } from '@xterm/addon-unicode11';
 import { log } from '@/utils/log';
+import { useWebGPURenderer } from './useWebGPURenderer';
 
 // 渲染模式类型
-export type RenderMode = 'auto' | 'webgl' | 'canvas' | 'dom';
+export type RenderMode = 'auto' | 'webgpu' | 'webgl' | 'canvas' | 'dom';
 
 // WebGL 上下文状态
 export type ContextState = 'active' | 'lost' | 'unavailable';
@@ -21,7 +22,9 @@ export interface RenderMetrics {
   /** 当前配置的渲染模式 */
   renderMode: RenderMode;
   /** 实际生效的渲染器类型 */
-  activeRenderer: 'webgl' | 'canvas' | 'dom';
+  activeRenderer: 'webgpu' | 'webgl' | 'canvas' | 'dom';
+  /** WebGPU 能力检测与设备初始化状态 */
+  webgpuState?: string;
   /** 当前 FPS（每 60 帧更新一次） */
   fps: number;
   /** 最近 60 帧的平均帧时间（毫秒） */
@@ -45,7 +48,7 @@ export function useTerminalRenderer(terminal: Ref<Terminal | null>, sessionId: s
   const renderMode = ref<RenderMode>('auto');
 
   /** 实际生效的渲染器类型 */
-  const activeRenderer = ref<'webgl' | 'canvas' | 'dom'>('dom');
+  const activeRenderer = ref<'webgpu' | 'webgl' | 'canvas' | 'dom'>('dom');
 
   /** WebGL 上下文状态 */
   const contextState = ref<ContextState>('unavailable');
@@ -58,6 +61,13 @@ export function useTerminalRenderer(terminal: Ref<Terminal | null>, sessionId: s
 
   /** 最近 60 帧的平均帧时间（毫秒） */
   const frameTime = ref(0);
+
+  const {
+    webgpuState,
+    isWebGPUSupported,
+    initGPUDevice,
+    dispose: disposeWebGPU,
+  } = useWebGPURenderer();
 
   // --- 内部状态 ---
 
@@ -122,6 +132,44 @@ export function useTerminalRenderer(terminal: Ref<Terminal | null>, sessionId: s
   }
 
   /**
+   * 应用 WebGPU 渲染模式
+   * 当前 @xterm/addon-webgpu 尚未接入，因此这里仅完成 WebGPU 能力检测与 GPUDevice 初始化；
+   * 实际终端画面仍复用现有 WebGL addon 渲染，方便后续无缝替换真实 WebGPU 渲染器。
+   */
+  async function applyWebGPURendererMode(term: Terminal): Promise<void> {
+    const supported = await isWebGPUSupported();
+    if (renderMode.value !== 'webgpu') return;
+
+    if (supported) {
+      const device = await initGPUDevice();
+      if (renderMode.value !== 'webgpu') return;
+
+      if (device) {
+        const success = loadWebglAddon(term);
+        if (success) {
+          activeRenderer.value = 'webgpu';
+          recoveryAttempts = 0;
+          log.info(`[Terminal ${sessionId}] WebGPU 设备已就绪，当前实际渲染暂由 WebGL addon 承担`);
+        } else {
+          activeRenderer.value = 'dom';
+          contextState.value = 'unavailable';
+        }
+        return;
+      }
+    }
+
+    // WebGPU 不可用或设备初始化失败时，沿用 webgl 强制模式的降级策略
+    const success = loadWebglAddon(term);
+    if (success) {
+      activeRenderer.value = 'webgl';
+      recoveryAttempts = 0;
+    } else {
+      activeRenderer.value = 'dom';
+      contextState.value = 'unavailable';
+    }
+  }
+
+  /**
    * 根据当前渲染模式处理 WebGL 上下文丢失后的恢复逻辑
    * - auto 模式：降级为 DOM 渲染器
    * - webgl 模式：尝试重新加载（最多 MAX_WEBGL_RECOVERY_ATTEMPTS 次）
@@ -167,6 +215,10 @@ export function useTerminalRenderer(terminal: Ref<Terminal | null>, sessionId: s
     disposeWebglAddon();
 
     switch (renderMode.value) {
+      case 'webgpu': {
+        void applyWebGPURendererMode(term);
+        break;
+      }
       case 'webgl': {
         const success = loadWebglAddon(term);
         if (success) {
@@ -280,7 +332,7 @@ export function useTerminalRenderer(terminal: Ref<Terminal | null>, sessionId: s
    * 获取完整的渲染性能指标
    */
   function getMetrics(): RenderMetrics {
-    return {
+    const metrics: RenderMetrics = {
       renderMode: renderMode.value,
       activeRenderer: activeRenderer.value,
       fps: fps.value,
@@ -288,6 +340,12 @@ export function useTerminalRenderer(terminal: Ref<Terminal | null>, sessionId: s
       contextState: contextState.value,
       contextLossCount: contextLossCount.value,
     };
+
+    if (renderMode.value === 'webgpu' || webgpuState.value !== 'unsupported') {
+      metrics.webgpuState = webgpuState.value;
+    }
+
+    return metrics;
   }
 
   // --- 初始化与清理 ---
@@ -320,6 +378,7 @@ export function useTerminalRenderer(terminal: Ref<Terminal | null>, sessionId: s
   function cleanup(): void {
     stopMonitoring();
     disposeWebglAddon();
+    disposeWebGPU();
     contextState.value = 'unavailable';
   }
 
@@ -340,6 +399,8 @@ export function useTerminalRenderer(terminal: Ref<Terminal | null>, sessionId: s
     fps,
     /** 最近 60 帧的平均帧时间（毫秒） */
     frameTime,
+    /** WebGPU 能力检测与设备初始化状态 */
+    webgpuState,
 
     /** 设置渲染模式并应用 */
     setRenderMode,

--- a/packages/frontend/src/composables/terminal/useTerminalRenderer.ts
+++ b/packages/frontend/src/composables/terminal/useTerminalRenderer.ts
@@ -172,6 +172,7 @@ export function useTerminalRenderer(terminal: Ref<Terminal | null>, sessionId: s
   /**
    * 根据当前渲染模式处理 WebGL 上下文丢失后的恢复逻辑
    * - auto 模式：降级为 DOM 渲染器
+   * - webgpu 模式：WebGL 是实际渲染后端，尝试重新加载（最多 MAX_WEBGL_RECOVERY_ATTEMPTS 次）
    * - webgl 模式：尝试重新加载（最多 MAX_WEBGL_RECOVERY_ATTEMPTS 次）
    */
   function handleContextLossRecovery(term: Terminal): void {
@@ -180,8 +181,8 @@ export function useTerminalRenderer(terminal: Ref<Terminal | null>, sessionId: s
       activeRenderer.value = 'dom';
       contextState.value = 'unavailable';
       log.info(`[Terminal ${sessionId}] auto 模式：WebGL 上下文丢失后降级为 DOM 渲染器`);
-    } else if (renderMode.value === 'webgl') {
-      // webgl 强制模式：尝试重新加载
+    } else if (renderMode.value === 'webgpu' || renderMode.value === 'webgl') {
+      // webgpu/webgl 模式：WebGL 是实际渲染后端，尝试重新加载
       if (recoveryAttempts < MAX_WEBGL_RECOVERY_ATTEMPTS) {
         recoveryAttempts++;
         log.info(
@@ -190,7 +191,8 @@ export function useTerminalRenderer(terminal: Ref<Terminal | null>, sessionId: s
         const success = loadWebglAddon(term);
         if (success) {
           recoveryAttempts = 0;
-          activeRenderer.value = 'webgl';
+          // 恢复成功时保持当前渲染模式标识
+          activeRenderer.value = renderMode.value === 'webgpu' ? 'webgpu' : 'webgl';
         } else {
           // 恢复失败，降级为 DOM 渲染器
           activeRenderer.value = 'dom';

--- a/packages/frontend/src/composables/terminal/useWebGPURenderer.ts
+++ b/packages/frontend/src/composables/terminal/useWebGPURenderer.ts
@@ -106,7 +106,9 @@ export function useWebGPURenderer(): WebGPURenderer {
         log.warn('[WebGPU] GPUDevice 初始化失败，使用降级渲染:', error);
         return null;
       }
-    })();
+    })().finally(() => {
+      initPromise = null;
+    });
 
     return initPromise;
   }

--- a/packages/frontend/src/composables/terminal/useWebGPURenderer.ts
+++ b/packages/frontend/src/composables/terminal/useWebGPURenderer.ts
@@ -40,6 +40,7 @@ export function useWebGPURenderer(): WebGPURenderer {
   const gpuDevice = ref<WebGPUDevice | null>(null);
 
   let gpuAdapter: WebGPUAdapter | null = null;
+  let initPromise: Promise<WebGPUDevice | null> | null = null;
 
   /**
    * 检测 WebGPU API 与适配器是否可用
@@ -82,23 +83,32 @@ export function useWebGPURenderer(): WebGPURenderer {
       return gpuDevice.value;
     }
 
-    const supported = await isWebGPUSupported();
-    if (!supported || !gpuAdapter) {
-      return null;
+    // 防止并发调用时创建多个 GPUDevice 实例
+    if (initPromise) {
+      return initPromise;
     }
 
-    try {
-      const device = await gpuAdapter.requestDevice();
-      gpuDevice.value = device;
-      webgpuState.value = 'active';
-      log.info('[WebGPU] GPUDevice 初始化成功');
-      return device;
-    } catch (error: unknown) {
-      gpuDevice.value = null;
-      webgpuState.value = 'error';
-      log.warn('[WebGPU] GPUDevice 初始化失败，使用降级渲染:', error);
-      return null;
-    }
+    initPromise = (async () => {
+      const supported = await isWebGPUSupported();
+      if (!supported || !gpuAdapter) {
+        return null;
+      }
+
+      try {
+        const device = await gpuAdapter.requestDevice();
+        gpuDevice.value = device;
+        webgpuState.value = 'active';
+        log.info('[WebGPU] GPUDevice 初始化成功');
+        return device;
+      } catch (error: unknown) {
+        gpuDevice.value = null;
+        webgpuState.value = 'error';
+        log.warn('[WebGPU] GPUDevice 初始化失败，使用降级渲染:', error);
+        return null;
+      }
+    })();
+
+    return initPromise;
   }
 
   /**
@@ -115,6 +125,7 @@ export function useWebGPURenderer(): WebGPURenderer {
     }
 
     gpuAdapter = null;
+    initPromise = null;
     webgpuState.value = 'unsupported';
   }
 

--- a/packages/frontend/src/composables/terminal/useWebGPURenderer.ts
+++ b/packages/frontend/src/composables/terminal/useWebGPURenderer.ts
@@ -1,0 +1,128 @@
+/**
+ * WebGPU 渲染能力管理
+ * 当前用于检测 WebGPU 能力并初始化 GPUDevice，为后续接入 xterm WebGPU 渲染器预留设备层。
+ */
+
+import { ref, type Ref } from 'vue';
+import { log } from '@/utils/log';
+
+export type WebGPUState = 'unsupported' | 'available' | 'active' | 'error';
+
+interface WebGPUNavigator extends Navigator {
+  gpu?: {
+    requestAdapter: () => Promise<WebGPUAdapter | null>;
+  };
+}
+
+export interface WebGPUDevice {
+  destroy: () => void;
+}
+
+interface WebGPUAdapter {
+  requestDevice: () => Promise<WebGPUDevice>;
+}
+
+export interface WebGPURenderer {
+  /** WebGPU 当前能力状态 */
+  webgpuState: Ref<WebGPUState>;
+  /** 当前已初始化的 GPUDevice */
+  gpuDevice: Ref<WebGPUDevice | null>;
+  /** 检测浏览器是否支持 WebGPU 并可获取适配器 */
+  isWebGPUSupported: () => Promise<boolean>;
+  /** 初始化 GPUDevice，成功时返回设备实例 */
+  initGPUDevice: () => Promise<WebGPUDevice | null>;
+  /** 释放 GPUDevice 资源 */
+  dispose: () => void;
+}
+
+export function useWebGPURenderer(): WebGPURenderer {
+  const webgpuState = ref<WebGPUState>('unsupported');
+  const gpuDevice = ref<WebGPUDevice | null>(null);
+
+  let gpuAdapter: WebGPUAdapter | null = null;
+
+  /**
+   * 检测 WebGPU API 与适配器是否可用
+   * @returns WebGPU 是否可用于初始化设备
+   */
+  async function isWebGPUSupported(): Promise<boolean> {
+    const webgpuNavigator =
+      typeof navigator === 'undefined' ? null : (navigator as WebGPUNavigator);
+
+    if (!webgpuNavigator?.gpu) {
+      webgpuState.value = 'unsupported';
+      log.info('[WebGPU] 当前环境不支持 navigator.gpu，使用降级渲染');
+      return false;
+    }
+
+    try {
+      gpuAdapter = await webgpuNavigator.gpu.requestAdapter();
+      if (!gpuAdapter) {
+        webgpuState.value = 'unsupported';
+        log.info('[WebGPU] 未获取到可用 GPUAdapter，使用降级渲染');
+        return false;
+      }
+
+      webgpuState.value = gpuDevice.value ? 'active' : 'available';
+      return true;
+    } catch (error: unknown) {
+      webgpuState.value = 'error';
+      log.warn('[WebGPU] 检测 WebGPU 能力失败，使用降级渲染:', error);
+      return false;
+    }
+  }
+
+  /**
+   * 初始化 GPUDevice
+   * 当前设备仅作为能力与资源准备层，实际终端渲染仍由现有 WebGL addon 承担。
+   */
+  async function initGPUDevice(): Promise<WebGPUDevice | null> {
+    if (gpuDevice.value) {
+      webgpuState.value = 'active';
+      return gpuDevice.value;
+    }
+
+    const supported = await isWebGPUSupported();
+    if (!supported || !gpuAdapter) {
+      return null;
+    }
+
+    try {
+      const device = await gpuAdapter.requestDevice();
+      gpuDevice.value = device;
+      webgpuState.value = 'active';
+      log.info('[WebGPU] GPUDevice 初始化成功');
+      return device;
+    } catch (error: unknown) {
+      gpuDevice.value = null;
+      webgpuState.value = 'error';
+      log.warn('[WebGPU] GPUDevice 初始化失败，使用降级渲染:', error);
+      return null;
+    }
+  }
+
+  /**
+   * 释放 GPUDevice
+   */
+  function dispose(): void {
+    if (gpuDevice.value) {
+      try {
+        gpuDevice.value.destroy();
+      } catch (error: unknown) {
+        log.warn('[WebGPU] 释放 GPUDevice 时发生异常:', error);
+      }
+      gpuDevice.value = null;
+    }
+
+    gpuAdapter = null;
+    webgpuState.value = 'unsupported';
+  }
+
+  return {
+    webgpuState,
+    gpuDevice,
+    isWebGPUSupported,
+    initGPUDevice,
+    dispose,
+  };
+}

--- a/packages/frontend/src/composables/useTouchGestures.test.ts
+++ b/packages/frontend/src/composables/useTouchGestures.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ref } from 'vue';
+import { useTouchGestures } from './useTouchGestures';
+
+interface TouchPointInit {
+  clientX: number;
+  clientY: number;
+  identifier?: number;
+}
+
+interface FakeTerminal {
+  rows: number;
+  scrollLines: (lines: number) => void;
+}
+
+const createTouchEvent = (type: string, points: TouchPointInit[]): TouchEvent => {
+  const event = new Event(type, { bubbles: true, cancelable: true }) as TouchEvent;
+  const touches = points.map((point: TouchPointInit, index: number) => ({
+    identifier: point.identifier ?? index,
+    clientX: point.clientX,
+    clientY: point.clientY,
+  })) as unknown as TouchList;
+
+  Object.defineProperty(event, 'touches', { value: touches });
+  Object.defineProperty(event, 'targetTouches', { value: touches });
+  Object.defineProperty(event, 'changedTouches', { value: touches });
+
+  return event;
+};
+
+describe('useTouchGestures', () => {
+  let element: HTMLDivElement;
+  let terminal: FakeTerminal;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    element = document.createElement('div');
+    terminal = {
+      rows: 24,
+      scrollLines: vi.fn(),
+    };
+    document.body.appendChild(element);
+    Object.defineProperty(navigator, 'vibrate', {
+      value: vi.fn(),
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('应在单指长按 500ms 后显示菜单并触发振动', () => {
+    const { attach, detach, isContextMenuVisible, contextMenuPosition } = useTouchGestures({
+      terminalRef: ref(element),
+      terminal: ref(terminal),
+    });
+
+    attach();
+    element.dispatchEvent(createTouchEvent('touchstart', [{ clientX: 120, clientY: 240 }]));
+    vi.advanceTimersByTime(500);
+
+    expect(isContextMenuVisible.value).toBe(true);
+    expect(contextMenuPosition.value).toEqual({ x: 120, y: 240 });
+    expect(navigator.vibrate).toHaveBeenCalledWith(35);
+    detach();
+  });
+
+  it('应按每 30px 滑动滚动三分之一终端行数', () => {
+    const { attach, detach } = useTouchGestures({
+      terminalRef: ref(element),
+      terminal: ref(terminal),
+    });
+
+    attach();
+    element.dispatchEvent(createTouchEvent('touchstart', [{ clientX: 20, clientY: 120 }]));
+    element.dispatchEvent(createTouchEvent('touchmove', [{ clientX: 20, clientY: 90 }]));
+    element.dispatchEvent(createTouchEvent('touchmove', [{ clientX: 20, clientY: 60 }]));
+
+    expect(terminal.scrollLines).toHaveBeenNthCalledWith(1, 8);
+    expect(terminal.scrollLines).toHaveBeenNthCalledWith(2, 8);
+    detach();
+  });
+
+  it('应忽略多指触摸并交给终端双指缩放处理', () => {
+    const { attach, detach, isContextMenuVisible } = useTouchGestures({
+      terminalRef: ref(element),
+      terminal: ref(terminal),
+    });
+
+    attach();
+    element.dispatchEvent(
+      createTouchEvent('touchstart', [
+        { clientX: 20, clientY: 120 },
+        { clientX: 80, clientY: 120 },
+      ])
+    );
+    element.dispatchEvent(
+      createTouchEvent('touchmove', [
+        { clientX: 20, clientY: 80 },
+        { clientX: 100, clientY: 120 },
+      ])
+    );
+    vi.advanceTimersByTime(500);
+
+    expect(isContextMenuVisible.value).toBe(false);
+    expect(terminal.scrollLines).not.toHaveBeenCalled();
+    detach();
+  });
+});

--- a/packages/frontend/src/composables/useTouchGestures.ts
+++ b/packages/frontend/src/composables/useTouchGestures.ts
@@ -69,6 +69,12 @@ export function useTouchGestures(options: TouchGestureOptions) {
     // 菜单已可见时，终端内触摸应关闭菜单而非启动新的长按计时器
     if (isContextMenuVisible.value) {
       hideContextMenu();
+      // 重置触摸基准坐标，避免后续 touchmove 使用过期的 scrollY 导致跳动
+      const touch = event.touches[0];
+      touchStartX = touch.clientX;
+      touchStartY = touch.clientY;
+      lastScrollY = touch.clientY;
+      clearLongPressTimer();
       return;
     }
 

--- a/packages/frontend/src/composables/useTouchGestures.ts
+++ b/packages/frontend/src/composables/useTouchGestures.ts
@@ -1,5 +1,6 @@
 import { getCurrentInstance, onBeforeUnmount, ref, type Ref } from 'vue';
 import type { Terminal } from '@xterm/xterm';
+import { log } from '@/utils/log';
 
 export interface ContextMenuPosition {
   x: number;
@@ -46,7 +47,13 @@ export function useTouchGestures(options: TouchGestureOptions) {
   };
 
   const showContextMenu = (x: number, y: number) => {
-    contextMenuPosition.value = { x, y };
+    // 限制菜单位置在视口范围内，防止在屏幕边缘长按时菜单被裁剪
+    const menuWidth = 140;
+    const menuHeight = 160;
+    const boundedX = Math.max(8, Math.min(x, window.innerWidth - menuWidth - 8));
+    const boundedY = Math.max(8, Math.min(y, window.innerHeight - menuHeight - 8));
+
+    contextMenuPosition.value = { x: boundedX, y: boundedY };
     isContextMenuVisible.value = true;
 
     // 长按反馈只在支持振动的移动设备上触发。
@@ -56,6 +63,12 @@ export function useTouchGestures(options: TouchGestureOptions) {
   const handleTouchStart = (event: TouchEvent) => {
     if (event.touches.length !== 1) {
       clearLongPressTimer();
+      return;
+    }
+
+    // 菜单已可见时，终端内触摸应关闭菜单而非启动新的长按计时器
+    if (isContextMenuVisible.value) {
+      hideContextMenu();
       return;
     }
 
@@ -125,21 +138,31 @@ export function useTouchGestures(options: TouchGestureOptions) {
       return;
     }
 
-    await navigator.clipboard.writeText(selectedText);
-    options.terminal.value?.clearSelection?.();
-    hideContextMenu();
+    try {
+      await navigator.clipboard.writeText(selectedText);
+      options.terminal.value?.clearSelection?.();
+    } catch (error: unknown) {
+      log.warn('[TouchGestures] 复制失败:', error);
+    } finally {
+      hideContextMenu();
+    }
   };
 
   const handlePaste = async () => {
-    const text = await navigator.clipboard.readText();
-    if (text) {
-      if (options.pasteText) {
-        options.pasteText(text);
-      } else {
-        options.terminal.value?.paste?.(text);
+    try {
+      const text = await navigator.clipboard.readText();
+      if (text) {
+        if (options.pasteText) {
+          options.pasteText(text);
+        } else {
+          options.terminal.value?.paste?.(text);
+        }
       }
+    } catch (error: unknown) {
+      log.warn('[TouchGestures] 粘贴失败:', error);
+    } finally {
+      hideContextMenu();
     }
-    hideContextMenu();
   };
 
   const handleSelectAll = () => {

--- a/packages/frontend/src/composables/useTouchGestures.ts
+++ b/packages/frontend/src/composables/useTouchGestures.ts
@@ -1,0 +1,193 @@
+import { getCurrentInstance, onBeforeUnmount, ref, type Ref } from 'vue';
+import type { Terminal } from '@xterm/xterm';
+
+export interface ContextMenuPosition {
+  x: number;
+  y: number;
+}
+
+type TerminalTouchTarget = Pick<Terminal, 'rows' | 'scrollLines'> &
+  Partial<Pick<Terminal, 'getSelection' | 'clearSelection' | 'paste' | 'selectAll'>>;
+
+export interface TouchGestureOptions {
+  terminal: Ref<TerminalTouchTarget | null>;
+  containerRef?: Ref<HTMLElement | null>;
+  terminalRef?: Ref<HTMLElement | null>;
+  getSelection?: () => string | null;
+  pasteText?: (text: string) => void;
+}
+
+const LONG_PRESS_DELAY = 500;
+const MOVE_CANCEL_THRESHOLD = 8;
+const SCROLL_STEP_PX = 30;
+
+export function useTouchGestures(options: TouchGestureOptions) {
+  const isContextMenuVisible = ref(false);
+  const contextMenuPosition = ref<ContextMenuPosition>({ x: 0, y: 0 });
+
+  let attachedElement: HTMLElement | null = null;
+  let longPressTimer: ReturnType<typeof setTimeout> | null = null;
+  let touchStartX = 0;
+  let touchStartY = 0;
+  let lastScrollY = 0;
+  let isAttached = false;
+
+  const getContainer = () => options.containerRef?.value ?? options.terminalRef?.value ?? null;
+
+  const clearLongPressTimer = () => {
+    if (longPressTimer) {
+      clearTimeout(longPressTimer);
+      longPressTimer = null;
+    }
+  };
+
+  const hideContextMenu = () => {
+    isContextMenuVisible.value = false;
+  };
+
+  const showContextMenu = (x: number, y: number) => {
+    contextMenuPosition.value = { x, y };
+    isContextMenuVisible.value = true;
+
+    // 长按反馈只在支持振动的移动设备上触发。
+    navigator.vibrate?.(35);
+  };
+
+  const handleTouchStart = (event: TouchEvent) => {
+    if (event.touches.length !== 1) {
+      clearLongPressTimer();
+      return;
+    }
+
+    const touch = event.touches[0];
+    touchStartX = touch.clientX;
+    touchStartY = touch.clientY;
+    lastScrollY = touch.clientY;
+
+    clearLongPressTimer();
+    longPressTimer = setTimeout(() => {
+      showContextMenu(touchStartX, touchStartY);
+      longPressTimer = null;
+    }, LONG_PRESS_DELAY);
+  };
+
+  const handleTouchMove = (event: TouchEvent) => {
+    if (event.touches.length !== 1) {
+      clearLongPressTimer();
+      return;
+    }
+
+    const touch = event.touches[0];
+    const totalDeltaX = touch.clientX - touchStartX;
+    const totalDeltaY = touch.clientY - touchStartY;
+
+    if (Math.hypot(totalDeltaX, totalDeltaY) > MOVE_CANCEL_THRESHOLD) {
+      clearLongPressTimer();
+    }
+
+    const terminal = options.terminal.value;
+    if (!terminal) return;
+
+    let scrollDelta = lastScrollY - touch.clientY;
+    const stepLines = Math.max(1, Math.round(terminal.rows / 3));
+
+    while (Math.abs(scrollDelta) >= SCROLL_STEP_PX) {
+      const direction = scrollDelta > 0 ? 1 : -1;
+      terminal.scrollLines(stepLines * direction);
+      lastScrollY -= SCROLL_STEP_PX * direction;
+      scrollDelta = lastScrollY - touch.clientY;
+    }
+
+    if (event.cancelable) {
+      event.preventDefault();
+    }
+  };
+
+  const handleTouchEnd = () => {
+    clearLongPressTimer();
+  };
+
+  const handleGlobalTouchStart = (event: TouchEvent) => {
+    if (!isContextMenuVisible.value) return;
+
+    const target = event.target as HTMLElement | null;
+    if (target?.closest('[data-touch-context-menu="true"]')) return;
+    if (target && getContainer()?.contains(target)) return;
+
+    hideContextMenu();
+  };
+
+  const handleCopy = async () => {
+    const selectedText =
+      options.getSelection?.() ?? options.terminal.value?.getSelection?.() ?? null;
+    if (!selectedText) {
+      hideContextMenu();
+      return;
+    }
+
+    await navigator.clipboard.writeText(selectedText);
+    options.terminal.value?.clearSelection?.();
+    hideContextMenu();
+  };
+
+  const handlePaste = async () => {
+    const text = await navigator.clipboard.readText();
+    if (text) {
+      if (options.pasteText) {
+        options.pasteText(text);
+      } else {
+        options.terminal.value?.paste?.(text);
+      }
+    }
+    hideContextMenu();
+  };
+
+  const handleSelectAll = () => {
+    options.terminal.value?.selectAll?.();
+    hideContextMenu();
+  };
+
+  const attach = () => {
+    if (isAttached) return;
+    const container = getContainer();
+    if (!container) return;
+
+    attachedElement = container;
+    attachedElement.addEventListener('touchstart', handleTouchStart, { passive: false });
+    attachedElement.addEventListener('touchmove', handleTouchMove, { passive: false });
+    attachedElement.addEventListener('touchend', handleTouchEnd);
+    attachedElement.addEventListener('touchcancel', handleTouchEnd);
+    document.addEventListener('touchstart', handleGlobalTouchStart, { passive: true });
+    isAttached = true;
+  };
+
+  const detach = () => {
+    clearLongPressTimer();
+    hideContextMenu();
+
+    if (attachedElement) {
+      attachedElement.removeEventListener('touchstart', handleTouchStart);
+      attachedElement.removeEventListener('touchmove', handleTouchMove);
+      attachedElement.removeEventListener('touchend', handleTouchEnd);
+      attachedElement.removeEventListener('touchcancel', handleTouchEnd);
+    }
+    document.removeEventListener('touchstart', handleGlobalTouchStart);
+    attachedElement = null;
+    isAttached = false;
+  };
+
+  if (getCurrentInstance()) {
+    onBeforeUnmount(detach);
+  }
+
+  return {
+    isContextMenuVisible,
+    contextMenuPosition,
+    hideContextMenu,
+    handleCopy,
+    handlePaste,
+    handleSelectAll,
+    attach,
+    detach,
+  };
+}

--- a/packages/frontend/src/composables/useTouchMouseMapping.test.ts
+++ b/packages/frontend/src/composables/useTouchMouseMapping.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ref } from 'vue';
+import { useTouchMouseMapping } from './useTouchMouseMapping';
+import type Guacamole from 'guacamole-common-js';
+
+interface TouchPointInit {
+  clientX: number;
+  clientY: number;
+  identifier?: number;
+}
+
+interface SentMouseState {
+  x: number;
+  y: number;
+  left: boolean;
+  middle: boolean;
+  right: boolean;
+  up: boolean;
+  down: boolean;
+}
+
+const createTouchEvent = (type: string, points: TouchPointInit[]): TouchEvent => {
+  const event = new Event(type, { bubbles: true, cancelable: true }) as TouchEvent;
+  const touches = points.map((point: TouchPointInit, index: number) => ({
+    identifier: point.identifier ?? index,
+    clientX: point.clientX,
+    clientY: point.clientY,
+  })) as unknown as TouchList;
+
+  Object.defineProperty(event, 'touches', { value: type === 'touchend' ? [] : touches });
+  Object.defineProperty(event, 'targetTouches', { value: type === 'touchend' ? [] : touches });
+  Object.defineProperty(event, 'changedTouches', { value: touches });
+
+  return event;
+};
+
+const createGuacamole = () =>
+  ({
+    Mouse: {
+      State: class {
+        x: number;
+        y: number;
+        left: boolean;
+        middle: boolean;
+        right: boolean;
+        up: boolean;
+        down: boolean;
+
+        constructor(
+          x: number,
+          y: number,
+          left: boolean,
+          middle: boolean,
+          right: boolean,
+          up: boolean,
+          down: boolean
+        ) {
+          this.x = x;
+          this.y = y;
+          this.left = left;
+          this.middle = middle;
+          this.right = right;
+          this.up = up;
+          this.down = down;
+        }
+      },
+    },
+  }) as unknown as typeof Guacamole;
+
+describe('useTouchMouseMapping', () => {
+  let element: HTMLDivElement;
+  let sendMouseState: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    element = document.createElement('div');
+    Object.defineProperty(element, 'getBoundingClientRect', {
+      value: () => ({ left: 10, top: 20, width: 300, height: 200 }),
+      configurable: true,
+    });
+    sendMouseState = vi.fn();
+    document.body.appendChild(element);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  it('absolute 模式应把触摸位置直接映射为屏幕坐标并发送左键点击', () => {
+    const { attach, detach } = useTouchMouseMapping({
+      element: ref(element),
+      client: ref({ sendMouseState } as unknown as InstanceType<typeof Guacamole.Client>),
+      Guacamole: createGuacamole(),
+      initialMode: 'absolute',
+    });
+
+    attach();
+    element.dispatchEvent(createTouchEvent('touchstart', [{ clientX: 110, clientY: 70 }]));
+    element.dispatchEvent(createTouchEvent('touchend', [{ clientX: 110, clientY: 70 }]));
+
+    const states = sendMouseState.mock.calls.map((call) => call[0] as SentMouseState);
+    expect(states.at(-2)).toMatchObject({ x: 100, y: 50, left: true });
+    expect(states.at(-1)).toMatchObject({ x: 100, y: 50, left: false });
+    detach();
+  });
+
+  it('relative 模式应按 1.5 倍灵敏度把滑动偏移映射为鼠标移动', () => {
+    const { attach, detach, setMode, mode } = useTouchMouseMapping({
+      element: ref(element),
+      client: ref({ sendMouseState } as unknown as InstanceType<typeof Guacamole.Client>),
+      Guacamole: createGuacamole(),
+      initialMode: 'absolute',
+    });
+
+    setMode('relative');
+    attach();
+    element.dispatchEvent(createTouchEvent('touchstart', [{ clientX: 50, clientY: 60 }]));
+    element.dispatchEvent(createTouchEvent('touchmove', [{ clientX: 70, clientY: 80 }]));
+
+    const lastState = sendMouseState.mock.calls.at(-1)?.[0] as SentMouseState;
+    expect(mode.value).toBe('relative');
+    expect(lastState).toMatchObject({ x: 30, y: 30, left: true });
+    detach();
+  });
+
+  it('单指长按和双指轻点都应发送右键点击', () => {
+    const { attach, detach } = useTouchMouseMapping({
+      element: ref(element),
+      client: ref({ sendMouseState } as unknown as InstanceType<typeof Guacamole.Client>),
+      Guacamole: createGuacamole(),
+      initialMode: 'absolute',
+    });
+
+    attach();
+    element.dispatchEvent(createTouchEvent('touchstart', [{ clientX: 110, clientY: 70 }]));
+    vi.advanceTimersByTime(500);
+    element.dispatchEvent(createTouchEvent('touchend', [{ clientX: 110, clientY: 70 }]));
+    element.dispatchEvent(
+      createTouchEvent('touchstart', [
+        { clientX: 130, clientY: 90 },
+        { clientX: 160, clientY: 90 },
+      ])
+    );
+    element.dispatchEvent(
+      createTouchEvent('touchend', [
+        { clientX: 130, clientY: 90 },
+        { clientX: 160, clientY: 90 },
+      ])
+    );
+
+    const rightStates = sendMouseState.mock.calls
+      .map((call) => call[0] as SentMouseState)
+      .filter((state) => state.right);
+    expect(rightStates).toHaveLength(2);
+    detach();
+  });
+});

--- a/packages/frontend/src/composables/useTouchMouseMapping.ts
+++ b/packages/frontend/src/composables/useTouchMouseMapping.ts
@@ -60,6 +60,7 @@ export function useTouchMouseMapping(options: TouchMouseMappingOptions) {
   let isAttached = false;
   let longPressTriggered = false;
   let suppressNextClickRelease = false;
+  let leftButtonSent = false;
 
   const getClient = () => options.guacClient?.value ?? options.client?.value ?? null;
   const getElement = () => options.displayEl?.value ?? options.element?.value ?? null;
@@ -197,13 +198,14 @@ export function useTouchMouseMapping(options: TouchMouseMappingOptions) {
     lastTouch = { x: touch.clientX, y: touch.clientY };
     longPressTriggered = false;
     suppressNextClickRelease = false;
+    leftButtonSent = false;
 
-    sendState(point, { left: true });
+    // 不立即发送左键按下，避免长按场景触发意外的拖拽/选区。
+    // 左键会在 touchmove 超过拖拽阈值时发送（确认为拖拽），或在 touchend 时作为 tap 发送。
 
     clearLongPressTimer();
     longPressTimer = setTimeout(() => {
       const currentPoint = mode.value === 'relative' ? lastSentPosition : getAbsolutePoint(touch);
-      sendState(currentPoint, { left: false });
       sendClick(currentPoint, 'right');
       longPressTriggered = true;
       suppressNextClickRelease = true;
@@ -229,9 +231,20 @@ export function useTouchMouseMapping(options: TouchMouseMappingOptions) {
       Math.hypot(touch.clientX - startTouch.x, touch.clientY - startTouch.y) > MOVE_CANCEL_THRESHOLD
     ) {
       clearLongPressTimer();
+      // 超过拖拽阈值，确认为拖拽：首次发送左键按下
+      if (!leftButtonSent && !longPressTriggered) {
+        const startPoint = getMappedPoint({
+          clientX: startTouch.x,
+          clientY: startTouch.y,
+        } as Touch);
+        sendState(startPoint, { left: true });
+        leftButtonSent = true;
+      }
     }
 
-    sendState(point, { left: !longPressTriggered });
+    if (leftButtonSent && !longPressTriggered) {
+      sendState(point, { left: true });
+    }
     lastTouch = { x: touch.clientX, y: touch.clientY };
   };
 
@@ -242,20 +255,31 @@ export function useTouchMouseMapping(options: TouchMouseMappingOptions) {
       sendClick(getCenterPoint(event.changedTouches), 'right');
       lastTouch = null;
       startTouch = null;
+      leftButtonSent = false;
       return;
     }
 
     const touch = event.changedTouches[0];
-    if (touch && !suppressNextClickRelease) {
-      sendState(mode.value === 'relative' ? lastSentPosition : getAbsolutePoint(touch), {
-        left: false,
-      });
+
+    if (leftButtonSent && !longPressTriggered) {
+      // 拖拽结束：释放左键
+      const endPoint = touch
+        ? mode.value === 'relative'
+          ? lastSentPosition
+          : getAbsolutePoint(touch)
+        : lastSentPosition;
+      sendState(endPoint, { left: false });
+    } else if (!longPressTriggered && !suppressNextClickRelease && touch) {
+      // 未拖拽且未长按：作为 tap 发送（按下 + 释放）
+      const tapPoint = mode.value === 'relative' ? lastSentPosition : getAbsolutePoint(touch);
+      sendClick(tapPoint, 'left');
     }
 
     lastTouch = null;
     startTouch = null;
     suppressNextClickRelease = false;
     longPressTriggered = false;
+    leftButtonSent = false;
   };
 
   const attach = () => {

--- a/packages/frontend/src/composables/useTouchMouseMapping.ts
+++ b/packages/frontend/src/composables/useTouchMouseMapping.ts
@@ -75,7 +75,7 @@ export function useTouchMouseMapping(options: TouchMouseMappingOptions) {
   const setMode = (newMode: MouseMappingMode) => {
     mode.value = newMode;
     lastTouch = null;
-    lastSentPosition = { x: 0, y: 0 };
+    // 不重置 lastSentPosition，避免切换到 relative 模式后鼠标跳到左上角
   };
 
   const createMouseState = (
@@ -122,9 +122,19 @@ export function useTouchMouseMapping(options: TouchMouseMappingOptions) {
     const rect = element?.getBoundingClientRect();
     if (!rect) return { x: touch.clientX, y: touch.clientY };
 
+    // 获取 Guacamole 画面缩放比例，将 CSS 像素坐标正确映射到远程桌面实际像素坐标
+    const client = getClient();
+    const displayGetter = client as unknown as {
+      getDisplay?: () => { getScale?: () => number };
+    } | null;
+    const scale =
+      displayGetter && typeof displayGetter.getDisplay === 'function'
+        ? (displayGetter.getDisplay().getScale?.() ?? 1)
+        : 1;
+
     return {
-      x: Math.min(Math.max(touch.clientX - rect.left, 0), rect.width),
-      y: Math.min(Math.max(touch.clientY - rect.top, 0), rect.height),
+      x: Math.min(Math.max((touch.clientX - rect.left) / scale, 0), rect.width / scale),
+      y: Math.min(Math.max((touch.clientY - rect.top) / scale, 0), rect.height / scale),
     };
   };
 
@@ -163,8 +173,14 @@ export function useTouchMouseMapping(options: TouchMouseMappingOptions) {
   const handleTouchStart = (event: TouchEvent) => {
     if (event.touches.length === 2) {
       clearLongPressTimer();
+      // 释放第一根手指触发的左键按下状态，防止双指轻点时远端残留悬停的左键
+      const point = getCenterPoint(event.touches);
+      sendState(point, { left: false });
       lastTouch = null;
       startTouch = null;
+      if (event.cancelable) {
+        event.preventDefault();
+      }
       return;
     }
 

--- a/packages/frontend/src/composables/useTouchMouseMapping.ts
+++ b/packages/frontend/src/composables/useTouchMouseMapping.ts
@@ -166,6 +166,13 @@ export function useTouchMouseMapping(options: TouchMouseMappingOptions) {
     return mode.value === 'relative' ? lastSentPosition : getAbsolutePoint(centerTouch);
   };
 
+  /** 获取释放左键时的坐标，避免嵌套三元表达式 */
+  const getEndPointForRelease = (touch: Touch | undefined): TouchPoint => {
+    if (!touch) return lastSentPosition;
+    if (mode.value === 'relative') return lastSentPosition;
+    return getAbsolutePoint(touch);
+  };
+
   const sendClick = (point: TouchPoint, button: 'left' | 'right') => {
     sendState(point, { [button]: true });
     sendState(point, { [button]: false });
@@ -192,7 +199,6 @@ export function useTouchMouseMapping(options: TouchMouseMappingOptions) {
     }
 
     const touch = event.touches[0];
-    const point = getMappedPoint(touch);
 
     startTouch = { x: touch.clientX, y: touch.clientY };
     lastTouch = { x: touch.clientX, y: touch.clientY };
@@ -233,10 +239,14 @@ export function useTouchMouseMapping(options: TouchMouseMappingOptions) {
       clearLongPressTimer();
       // 超过拖拽阈值，确认为拖拽：首次发送左键按下
       if (!leftButtonSent && !longPressTriggered) {
-        const startPoint = getMappedPoint({
-          clientX: startTouch.x,
-          clientY: startTouch.y,
-        } as Touch);
+        // relative 模式下使用 lastSentPosition，避免从触摸起点映射导致光标跳动
+        const startPoint =
+          mode.value === 'relative'
+            ? lastSentPosition
+            : getAbsolutePoint({
+                clientX: startTouch.x,
+                clientY: startTouch.y,
+              } as Touch);
         sendState(startPoint, { left: true });
         leftButtonSent = true;
       }
@@ -263,11 +273,7 @@ export function useTouchMouseMapping(options: TouchMouseMappingOptions) {
 
     if (leftButtonSent && !longPressTriggered) {
       // 拖拽结束：释放左键
-      const endPoint = touch
-        ? mode.value === 'relative'
-          ? lastSentPosition
-          : getAbsolutePoint(touch)
-        : lastSentPosition;
+      const endPoint = getEndPointForRelease(touch);
       sendState(endPoint, { left: false });
     } else if (!longPressTriggered && !suppressNextClickRelease && touch) {
       // 未拖拽且未长按：作为 tap 发送（按下 + 释放）

--- a/packages/frontend/src/composables/useTouchMouseMapping.ts
+++ b/packages/frontend/src/composables/useTouchMouseMapping.ts
@@ -1,0 +1,286 @@
+import { getCurrentInstance, onBeforeUnmount, ref, type Ref } from 'vue';
+import GuacamoleDefault from 'guacamole-common-js';
+
+export type MouseMappingMode = 'absolute' | 'relative';
+
+export interface TouchMouseMappingOptions {
+  guacClient?: Ref<GuacamoleClientLike | null>;
+  displayEl?: Ref<HTMLElement | null>;
+  client?: Ref<GuacamoleClientLike | null>;
+  element?: Ref<HTMLElement | null>;
+  Guacamole?: typeof GuacamoleDefault;
+  initialMode?: MouseMappingMode;
+}
+
+interface MouseStateLike {
+  x: number;
+  y: number;
+  left: boolean;
+  middle: boolean;
+  right: boolean;
+  up: boolean;
+  down: boolean;
+}
+
+interface GuacamoleClientLike {
+  sendMouseState(state: MouseStateLike): void;
+}
+
+type GuacamoleRuntime = typeof GuacamoleDefault & {
+  Mouse: typeof GuacamoleDefault.Mouse & {
+    State?: new (
+      x: number,
+      y: number,
+      left: boolean,
+      middle: boolean,
+      right: boolean,
+      up: boolean,
+      down: boolean
+    ) => MouseStateLike;
+  };
+};
+
+interface TouchPoint {
+  x: number;
+  y: number;
+}
+
+const LONG_PRESS_DELAY = 500;
+const MOVE_CANCEL_THRESHOLD = 8;
+const RELATIVE_SENSITIVITY = 1.5;
+
+export function useTouchMouseMapping(options: TouchMouseMappingOptions) {
+  const mode = ref<MouseMappingMode>(options.initialMode ?? 'absolute');
+
+  let attachedElement: HTMLElement | null = null;
+  let longPressTimer: ReturnType<typeof setTimeout> | null = null;
+  let lastTouch: TouchPoint | null = null;
+  let startTouch: TouchPoint | null = null;
+  let lastSentPosition: TouchPoint = { x: 0, y: 0 };
+  let isAttached = false;
+  let longPressTriggered = false;
+  let suppressNextClickRelease = false;
+
+  const getClient = () => options.guacClient?.value ?? options.client?.value ?? null;
+  const getElement = () => options.displayEl?.value ?? options.element?.value ?? null;
+  const getGuacamole = () => (options.Guacamole ?? GuacamoleDefault) as GuacamoleRuntime;
+
+  const clearLongPressTimer = () => {
+    if (longPressTimer) {
+      clearTimeout(longPressTimer);
+      longPressTimer = null;
+    }
+  };
+
+  const setMode = (newMode: MouseMappingMode) => {
+    mode.value = newMode;
+    lastTouch = null;
+    lastSentPosition = { x: 0, y: 0 };
+  };
+
+  const createMouseState = (
+    x: number,
+    y: number,
+    buttons: { left?: boolean; middle?: boolean; right?: boolean } = {}
+  ): MouseStateLike => {
+    const roundedX = Math.round(x);
+    const roundedY = Math.round(y);
+    const left = Boolean(buttons.left);
+    const middle = Boolean(buttons.middle);
+    const right = Boolean(buttons.right);
+    const StateCtor = getGuacamole().Mouse.State;
+
+    if (StateCtor) {
+      return new StateCtor(roundedX, roundedY, left, middle, right, false, false);
+    }
+
+    // 类型声明缺少 State 构造函数时，使用 Guacamole 兼容的状态对象。
+    return {
+      x: roundedX,
+      y: roundedY,
+      left,
+      middle,
+      right,
+      up: false,
+      down: false,
+    };
+  };
+
+  const sendState = (
+    point: TouchPoint,
+    buttons: { left?: boolean; middle?: boolean; right?: boolean } = {}
+  ) => {
+    const client = getClient();
+    if (!client) return;
+
+    client.sendMouseState(createMouseState(point.x, point.y, buttons));
+    lastSentPosition = point;
+  };
+
+  const getAbsolutePoint = (touch: Touch): TouchPoint => {
+    const element = getElement();
+    const rect = element?.getBoundingClientRect();
+    if (!rect) return { x: touch.clientX, y: touch.clientY };
+
+    return {
+      x: Math.min(Math.max(touch.clientX - rect.left, 0), rect.width),
+      y: Math.min(Math.max(touch.clientY - rect.top, 0), rect.height),
+    };
+  };
+
+  const getRelativePoint = (touch: Touch): TouchPoint => {
+    if (!lastTouch) return lastSentPosition;
+
+    return {
+      x: lastSentPosition.x + (touch.clientX - lastTouch.x) * RELATIVE_SENSITIVITY,
+      y: lastSentPosition.y + (touch.clientY - lastTouch.y) * RELATIVE_SENSITIVITY,
+    };
+  };
+
+  const getMappedPoint = (touch: Touch): TouchPoint => {
+    if (mode.value === 'relative') {
+      return getRelativePoint(touch);
+    }
+    return getAbsolutePoint(touch);
+  };
+
+  const getCenterPoint = (touches: TouchList): TouchPoint => {
+    const first = touches[0];
+    const second = touches[1] ?? touches[0];
+    const centerTouch = {
+      clientX: (first.clientX + second.clientX) / 2,
+      clientY: (first.clientY + second.clientY) / 2,
+    } as Touch;
+
+    return mode.value === 'relative' ? lastSentPosition : getAbsolutePoint(centerTouch);
+  };
+
+  const sendClick = (point: TouchPoint, button: 'left' | 'right') => {
+    sendState(point, { [button]: true });
+    sendState(point, { [button]: false });
+  };
+
+  const handleTouchStart = (event: TouchEvent) => {
+    if (event.touches.length === 2) {
+      clearLongPressTimer();
+      lastTouch = null;
+      startTouch = null;
+      return;
+    }
+
+    if (event.touches.length !== 1) return;
+
+    if (event.cancelable) {
+      event.preventDefault();
+    }
+
+    const touch = event.touches[0];
+    const point = getMappedPoint(touch);
+
+    startTouch = { x: touch.clientX, y: touch.clientY };
+    lastTouch = { x: touch.clientX, y: touch.clientY };
+    longPressTriggered = false;
+    suppressNextClickRelease = false;
+
+    sendState(point, { left: true });
+
+    clearLongPressTimer();
+    longPressTimer = setTimeout(() => {
+      const currentPoint = mode.value === 'relative' ? lastSentPosition : getAbsolutePoint(touch);
+      sendState(currentPoint, { left: false });
+      sendClick(currentPoint, 'right');
+      longPressTriggered = true;
+      suppressNextClickRelease = true;
+      longPressTimer = null;
+    }, LONG_PRESS_DELAY);
+  };
+
+  const handleTouchMove = (event: TouchEvent) => {
+    if (event.touches.length !== 1) {
+      clearLongPressTimer();
+      return;
+    }
+
+    if (event.cancelable) {
+      event.preventDefault();
+    }
+
+    const touch = event.touches[0];
+    const point = getMappedPoint(touch);
+
+    if (
+      startTouch &&
+      Math.hypot(touch.clientX - startTouch.x, touch.clientY - startTouch.y) > MOVE_CANCEL_THRESHOLD
+    ) {
+      clearLongPressTimer();
+    }
+
+    sendState(point, { left: !longPressTriggered });
+    lastTouch = { x: touch.clientX, y: touch.clientY };
+  };
+
+  const handleTouchEnd = (event: TouchEvent) => {
+    clearLongPressTimer();
+
+    if (event.changedTouches.length >= 2) {
+      sendClick(getCenterPoint(event.changedTouches), 'right');
+      lastTouch = null;
+      startTouch = null;
+      return;
+    }
+
+    const touch = event.changedTouches[0];
+    if (touch && !suppressNextClickRelease) {
+      sendState(mode.value === 'relative' ? lastSentPosition : getAbsolutePoint(touch), {
+        left: false,
+      });
+    }
+
+    lastTouch = null;
+    startTouch = null;
+    suppressNextClickRelease = false;
+    longPressTriggered = false;
+  };
+
+  const attach = () => {
+    if (isAttached) return;
+    const element = getElement();
+    if (!element) return;
+
+    attachedElement = element;
+    attachedElement.addEventListener('touchstart', handleTouchStart, { passive: false });
+    attachedElement.addEventListener('touchmove', handleTouchMove, { passive: false });
+    attachedElement.addEventListener('touchend', handleTouchEnd, { passive: false });
+    attachedElement.addEventListener('touchcancel', handleTouchEnd, { passive: false });
+    isAttached = true;
+  };
+
+  const detach = () => {
+    clearLongPressTimer();
+
+    if (attachedElement) {
+      attachedElement.removeEventListener('touchstart', handleTouchStart);
+      attachedElement.removeEventListener('touchmove', handleTouchMove);
+      attachedElement.removeEventListener('touchend', handleTouchEnd);
+      attachedElement.removeEventListener('touchcancel', handleTouchEnd);
+    }
+
+    attachedElement = null;
+    lastTouch = null;
+    startTouch = null;
+    isAttached = false;
+    suppressNextClickRelease = false;
+    longPressTriggered = false;
+  };
+
+  if (getCurrentInstance()) {
+    onBeforeUnmount(detach);
+  }
+
+  return {
+    mode,
+    setMode,
+    attach,
+    detach,
+  };
+}

--- a/packages/frontend/src/composables/useVideoDecoder.ts
+++ b/packages/frontend/src/composables/useVideoDecoder.ts
@@ -1,0 +1,261 @@
+/**
+ * WebCodecs 视频解码器
+ * 用于硬件加速视频帧解码，并在可用时使用高效的 bitmaprenderer 渲染路径。
+ */
+
+import { ref, type Ref } from 'vue';
+import { log } from '@/utils/log';
+
+export interface UseVideoDecoderOptions {
+  /** 用于承载解码帧的画布 */
+  canvas: Ref<HTMLCanvasElement | null> | HTMLCanvasElement | null;
+  /** 视频编码格式，默认使用 H.264 */
+  codec?: string;
+  /** 是否优先降低延迟 */
+  optimizeForLatency?: boolean;
+}
+
+export interface VideoDecoderController {
+  /** 当前浏览器是否支持 WebCodecs 解码能力 */
+  isSupported: Ref<boolean>;
+  /** 当前是否使用 OffscreenCanvas 渲染路径 */
+  isUsingOffscreen: Ref<boolean>;
+  /** 初始化 VideoDecoder */
+  init: () => Promise<boolean>;
+  /** 解码单个编码视频帧 */
+  decodeFrame: (data: BufferSource, timestamp: number, isKeyFrame: boolean) => void;
+  /** 释放解码器与渲染引用 */
+  dispose: () => void;
+}
+
+type RenderCanvas = HTMLCanvasElement | OffscreenCanvas;
+type Canvas2DContext = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+
+const DEFAULT_CODEC = 'avc1';
+
+function isCanvasRef(
+  canvas: Ref<HTMLCanvasElement | null> | HTMLCanvasElement | null
+): canvas is Ref<HTMLCanvasElement | null> {
+  return Boolean(canvas && typeof canvas === 'object' && 'value' in canvas);
+}
+
+export function useVideoDecoder(options: UseVideoDecoderOptions): VideoDecoderController {
+  const isSupported = ref(false);
+  const isUsingOffscreen = ref(false);
+
+  let videoDecoder: VideoDecoder | null = null;
+  let renderCanvas: RenderCanvas | null = null;
+  let bitmapContext: ImageBitmapRenderingContext | null = null;
+  let canvas2dContext: Canvas2DContext | null = null;
+
+  /**
+   * 获取当前目标画布
+   */
+  function getCanvas(): HTMLCanvasElement | null {
+    return isCanvasRef(options.canvas) ? options.canvas.value : options.canvas;
+  }
+
+  /**
+   * 检测 WebCodecs 基础能力
+   */
+  function hasWebCodecsSupport(): boolean {
+    return (
+      typeof window !== 'undefined' && 'VideoDecoder' in window && 'EncodedVideoChunk' in window
+    );
+  }
+
+  /**
+   * 准备渲染画布和上下文
+   * 优先使用 OffscreenCanvas 和 bitmaprenderer，失败时降级为主线程 2D Canvas。
+   */
+  function setupRenderSurface(): boolean {
+    if (bitmapContext || canvas2dContext) {
+      return true;
+    }
+
+    const canvas = getCanvas();
+    if (!canvas) {
+      log.warn('[VideoDecoder] 未找到可用 canvas，跳过视频帧渲染');
+      return false;
+    }
+
+    if (!renderCanvas) {
+      const canTransferOffscreen =
+        typeof OffscreenCanvas !== 'undefined' && 'transferControlToOffscreen' in canvas;
+
+      if (canTransferOffscreen) {
+        try {
+          renderCanvas = canvas.transferControlToOffscreen();
+          isUsingOffscreen.value = true;
+        } catch (error: unknown) {
+          renderCanvas = canvas;
+          isUsingOffscreen.value = false;
+          log.warn('[VideoDecoder] OffscreenCanvas 初始化失败，降级为主线程 Canvas:', error);
+        }
+      } else {
+        renderCanvas = canvas;
+        isUsingOffscreen.value = false;
+      }
+    }
+
+    try {
+      bitmapContext = renderCanvas.getContext(
+        'bitmaprenderer'
+      ) as ImageBitmapRenderingContext | null;
+    } catch (error: unknown) {
+      bitmapContext = null;
+      log.warn('[VideoDecoder] bitmaprenderer 上下文不可用，尝试 2D Canvas:', error);
+    }
+
+    if (!bitmapContext) {
+      try {
+        canvas2dContext = renderCanvas.getContext('2d') as Canvas2DContext | null;
+      } catch (error: unknown) {
+        canvas2dContext = null;
+        log.warn('[VideoDecoder] 2D Canvas 上下文不可用:', error);
+      }
+    }
+
+    return Boolean(bitmapContext || canvas2dContext);
+  }
+
+  /**
+   * 渲染已解码的视频帧
+   * VideoFrame 必须在使用后 close，避免长期远程桌面会话泄漏内存。
+   */
+  async function handleDecodedFrame(frame: VideoFrame): Promise<void> {
+    try {
+      if (!setupRenderSurface()) {
+        return;
+      }
+
+      if (bitmapContext && typeof createImageBitmap !== 'undefined') {
+        const bitmap = await createImageBitmap(frame);
+        try {
+          bitmapContext.transferFromImageBitmap(bitmap);
+        } finally {
+          bitmap.close();
+        }
+        return;
+      }
+
+      if (canvas2dContext) {
+        const width = frame.displayWidth || frame.codedWidth;
+        const height = frame.displayHeight || frame.codedHeight;
+        canvas2dContext.drawImage(frame, 0, 0, width, height);
+      }
+    } catch (error: unknown) {
+      log.warn('[VideoDecoder] 渲染视频帧失败:', error);
+    } finally {
+      frame.close();
+    }
+  }
+
+  /**
+   * 初始化 WebCodecs VideoDecoder
+   */
+  async function init(): Promise<boolean> {
+    dispose();
+
+    if (!hasWebCodecsSupport()) {
+      isSupported.value = false;
+      log.info('[VideoDecoder] 当前浏览器不支持 WebCodecs，使用现有渲染路径');
+      return false;
+    }
+
+    const canvas = getCanvas();
+    if (!canvas) {
+      isSupported.value = false;
+      log.warn('[VideoDecoder] 初始化失败：缺少目标 canvas');
+      return false;
+    }
+
+    try {
+      const decoderConfig: VideoDecoderConfig = {
+        codec: options.codec || DEFAULT_CODEC,
+        optimizeForLatency: options.optimizeForLatency ?? true,
+      };
+
+      const support = await VideoDecoder.isConfigSupported(decoderConfig);
+      if (!support.supported) {
+        isSupported.value = false;
+        log.info(`[VideoDecoder] 当前 codec 不受支持: ${decoderConfig.codec}`);
+        return false;
+      }
+
+      if (!setupRenderSurface()) {
+        isSupported.value = false;
+        return false;
+      }
+
+      videoDecoder = new VideoDecoder({
+        output: (frame: VideoFrame) => {
+          void handleDecodedFrame(frame);
+        },
+        error: (error: DOMException) => {
+          isSupported.value = false;
+          log.warn('[VideoDecoder] 解码器运行错误:', error);
+        },
+      });
+      videoDecoder.configure(decoderConfig);
+      isSupported.value = true;
+      log.info(`[VideoDecoder] WebCodecs 解码器已初始化，codec=${decoderConfig.codec}`);
+      return true;
+    } catch (error: unknown) {
+      isSupported.value = false;
+      videoDecoder = null;
+      log.warn('[VideoDecoder] 初始化 WebCodecs 解码器失败:', error);
+      return false;
+    }
+  }
+
+  /**
+   * 解码一个编码视频帧
+   */
+  function decodeFrame(data: BufferSource, timestamp: number, isKeyFrame: boolean): void {
+    if (!videoDecoder || videoDecoder.state !== 'configured') {
+      log.warn('[VideoDecoder] 解码器尚未就绪，丢弃视频帧');
+      return;
+    }
+
+    try {
+      const chunk = new EncodedVideoChunk({
+        type: isKeyFrame ? 'key' : 'delta',
+        timestamp,
+        data,
+      });
+      videoDecoder.decode(chunk);
+    } catch (error: unknown) {
+      log.warn('[VideoDecoder] 提交视频帧解码失败:', error);
+    }
+  }
+
+  /**
+   * 释放解码器与渲染引用
+   */
+  function dispose(): void {
+    if (videoDecoder) {
+      try {
+        if (videoDecoder.state !== 'closed') {
+          videoDecoder.close();
+        }
+      } catch (error: unknown) {
+        log.warn('[VideoDecoder] 关闭解码器时发生异常:', error);
+      }
+      videoDecoder = null;
+    }
+
+    renderCanvas = null;
+    bitmapContext = null;
+    canvas2dContext = null;
+    isUsingOffscreen.value = false;
+  }
+
+  return {
+    isSupported,
+    isUsingOffscreen,
+    init,
+    decodeFrame,
+    dispose,
+  };
+}

--- a/packages/frontend/src/composables/useVideoDecoder.ts
+++ b/packages/frontend/src/composables/useVideoDecoder.ts
@@ -31,7 +31,7 @@ export interface VideoDecoderController {
 type RenderCanvas = HTMLCanvasElement | OffscreenCanvas;
 type Canvas2DContext = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
 
-const DEFAULT_CODEC = 'avc1';
+const DEFAULT_CODEC = 'avc1.42001E';
 
 function isCanvasRef(
   canvas: Ref<HTMLCanvasElement | null> | HTMLCanvasElement | null
@@ -85,7 +85,12 @@ export function useVideoDecoder(options: UseVideoDecoderOptions): VideoDecoderCo
 
       if (canTransferOffscreen) {
         try {
-          renderCanvas = canvas.transferControlToOffscreen();
+          // 缓存已转换的 OffscreenCanvas 到 canvas 元素上，防止重复调用 transferControlToOffscreen
+          const customCanvas = canvas as HTMLCanvasElement & { _offscreenCanvas?: OffscreenCanvas };
+          if (!customCanvas._offscreenCanvas) {
+            customCanvas._offscreenCanvas = canvas.transferControlToOffscreen();
+          }
+          renderCanvas = customCanvas._offscreenCanvas;
           isUsingOffscreen.value = true;
         } catch (error: unknown) {
           renderCanvas = canvas;

--- a/packages/frontend/src/features/terminal/Terminal.vue
+++ b/packages/frontend/src/features/terminal/Terminal.vue
@@ -35,6 +35,7 @@ const { t } = useI18n();
 import { useTerminalFit } from '../../composables/terminal/useTerminalFit';
 import { useTerminalSocket } from '../../composables/terminal/useTerminalSocket';
 import { useTerminalRenderer } from '../../composables/terminal/useTerminalRenderer';
+import { useTouchGestures } from '../../composables/useTouchGestures';
 import { OutputEnhancerAddon } from './addons/output-enhancer';
 import PerformanceMonitor from './components/PerformanceMonitor.vue';
 import { log } from '@/utils/log';
@@ -162,6 +163,34 @@ const getScrollbackValue = (limit: number): number => {
   return Math.max(0, limit);
 };
 
+const sendPastedTextToTerminal = (text: string) => {
+  const processedText = text.replace(/\r\n?/g, '\n');
+  // 移动端菜单复用桌面粘贴策略，确保 bracketed paste 行为一致。
+  const data = terminalEnableBracketedPasteBoolean.value
+    ? `\x1b[200~${processedText}\x1b[201~`
+    : processedText;
+  emitWorkspaceEvent('terminal:input', {
+    sessionId: props.sessionId,
+    data,
+  });
+};
+
+const {
+  isContextMenuVisible: isTouchContextMenuVisible,
+  contextMenuPosition: touchContextMenuPosition,
+  hideContextMenu: hideTouchContextMenu,
+  handleCopy: handleTouchCopy,
+  handlePaste: handleTouchPaste,
+  handleSelectAll: handleTouchSelectAll,
+  attach: attachTouchGestures,
+  detach: detachTouchGestures,
+} = useTouchGestures({
+  terminal: terminalInstance,
+  terminalRef,
+  getSelection: () => terminalInstance.value?.getSelection() ?? null,
+  pasteText: sendPastedTextToTerminal,
+});
+
 const MIN_TERMINAL_COLS_NO_WRAP = 240;
 
 const syncNoWrapContentWidth = (term: Terminal) => {
@@ -244,16 +273,7 @@ const handleContextMenuPaste = async (event: MouseEvent) => {
   try {
     const text = await navigator.clipboard.readText();
     if (text) {
-      const processedText = text.replace(/\r\n?/g, '\n');
-      // 根据设置决定是否使用 Bracketed Paste Mode 包裹
-      // 关闭 bracketed paste 可解决基础 sh 环境下转义序列显示异常问题
-      const data = terminalEnableBracketedPasteBoolean.value
-        ? `\x1b[200~${processedText}\x1b[201~`
-        : processedText;
-      emitWorkspaceEvent('terminal:input', {
-        sessionId: props.sessionId,
-        data,
-      });
+      sendPastedTextToTerminal(text);
     }
   } catch (err: unknown) {
     log.error('[Terminal] Failed to paste via Right Click:', err);
@@ -586,6 +606,7 @@ onMounted(() => {
       terminalRef.value.addEventListener('touchmove', handleTouchMove, { passive: false });
       terminalRef.value.addEventListener('touchend', handleTouchEnd, { passive: false });
       terminalRef.value.addEventListener('touchcancel', handleTouchEnd, { passive: false });
+      attachTouchGestures();
     }
   }
 });
@@ -621,6 +642,7 @@ onBeforeUnmount(() => {
     terminalRef.value.removeEventListener('touchmove', handleTouchMove);
     terminalRef.value.removeEventListener('touchend', handleTouchEnd);
     terminalRef.value.removeEventListener('touchcancel', handleTouchEnd);
+    detachTouchGestures();
   }
 
   if (terminalRef.value) {
@@ -727,6 +749,26 @@ watchEffect(() => {
     <div ref="terminalRef" class="terminal-inner-container"></div>
     <PerformanceMonitor :metrics="getMetrics()" :visible="isFpsEnabled" />
   </div>
+  <Teleport to="body">
+    <div
+      v-if="isTouchContextMenuVisible"
+      data-touch-context-menu="true"
+      class="terminal-touch-context-menu"
+      :style="{
+        left: `${touchContextMenuPosition.x}px`,
+        top: `${touchContextMenuPosition.y}px`,
+      }"
+      @touchstart.stop
+      @click.stop
+    >
+      <button type="button" @click="handleTouchCopy">{{ t('common.copy', '复制') }}</button>
+      <button type="button" @click="handleTouchPaste">{{ t('common.paste', '粘贴') }}</button>
+      <button type="button" @click="handleTouchSelectAll">
+        {{ t('common.selectAll', '全选') }}
+      </button>
+      <button type="button" @click="hideTouchContextMenu">{{ t('common.cancel', '取消') }}</button>
+    </div>
+  </Teleport>
 </template>
 
 <style scoped>
@@ -759,6 +801,37 @@ watchEffect(() => {
 .terminal-inner-container :deep(.xterm-screen canvas) {
   image-rendering: -webkit-optimize-contrast;
   image-rendering: crisp-edges;
+}
+
+.terminal-touch-context-menu {
+  position: fixed;
+  z-index: 3000;
+  min-width: 132px;
+  padding: 6px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--header-bg-color);
+  box-shadow: 0 8px 24px rgb(0 0 0 / 22%);
+  transform: translate(-8px, -8px);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.terminal-touch-context-menu button {
+  min-height: 36px;
+  padding: 0 12px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-color);
+  font-size: 14px;
+  line-height: 1.2;
+  text-align: left;
+}
+
+.terminal-touch-context-menu button:active {
+  background: var(--nav-item-active-bg-color);
 }
 
 .terminal-outer-wrapper.no-auto-wrap :deep(.xterm-viewport) {

--- a/packages/frontend/src/stores/appearance.store.test.ts
+++ b/packages/frontend/src/stores/appearance.store.test.ts
@@ -467,6 +467,60 @@ describe('appearance.store', () => {
 
       expect(store.currentTerminalFontSize).toBe(14);
     });
+
+    it('terminalRenderMode 为 webgpu 时应正确设置 currentRenderMode', async () => {
+      mockGet.mockResolvedValueOnce({ data: { terminalRenderMode: 'webgpu' } });
+      mockGet.mockResolvedValueOnce({ data: [] });
+
+      const { useAppearanceStore } = await import('./appearance.store');
+      const store = useAppearanceStore();
+
+      await store.loadInitialAppearanceData();
+
+      expect(store.currentRenderMode).toBe('webgpu');
+    });
+
+    it('terminalRenderMode 为非法字符串时应回退到 auto', async () => {
+      mockGet.mockResolvedValueOnce({ data: { terminalRenderMode: 'invalid_mode' } });
+      mockGet.mockResolvedValueOnce({ data: [] });
+
+      const { useAppearanceStore } = await import('./appearance.store');
+      const store = useAppearanceStore();
+
+      await store.loadInitialAppearanceData();
+
+      expect(store.currentRenderMode).toBe('auto');
+    });
+
+    it('setRenderMode 成功应更新 currentRenderMode', async () => {
+      mockGet.mockResolvedValueOnce({ data: {} });
+      mockGet.mockResolvedValueOnce({ data: [] });
+      mockPut.mockResolvedValueOnce({ data: { terminalRenderMode: 'webgpu' } });
+
+      const { useAppearanceStore } = await import('./appearance.store');
+      const store = useAppearanceStore();
+
+      await store.loadInitialAppearanceData();
+      await store.setRenderMode('webgpu');
+
+      expect(store.currentRenderMode).toBe('webgpu');
+    });
+
+    it('setRenderMode 失败应回滚到之前的模式', async () => {
+      mockGet.mockResolvedValueOnce({ data: { terminalRenderMode: 'auto' } });
+      mockGet.mockResolvedValueOnce({ data: [] });
+      mockPut.mockRejectedValueOnce(new Error('update failed'));
+
+      const { useAppearanceStore } = await import('./appearance.store');
+      const store = useAppearanceStore();
+
+      await store.loadInitialAppearanceData();
+      expect(store.currentRenderMode).toBe('auto');
+
+      await store.setRenderMode('webgpu').catch(() => {});
+
+      expect(store.currentRenderMode).toBe('auto');
+    });
   });
 
   describe('子 Store 代理属性', () => {

--- a/packages/frontend/src/stores/appearance.store.ts
+++ b/packages/frontend/src/stores/appearance.store.ts
@@ -25,7 +25,7 @@ import { createHtmlPresetsStore } from './appearance-html-presets.store';
 import { log } from '@/utils/log';
 
 // 终端渲染模式类型（内联定义，避免循环依赖）
-export type RenderMode = 'auto' | 'webgl' | 'canvas' | 'dom';
+export type RenderMode = 'auto' | 'webgpu' | 'webgl' | 'canvas' | 'dom';
 
 // 重新导出 safeJsonParse 供外部使用（如 StyleCustomizerUiTab.vue）
 export { safeJsonParse };
@@ -96,7 +96,7 @@ export const useAppearanceStore = defineStore('appearance', () => {
   });
 
   // --- 渲染模式与 FPS ---
-  const VALID_RENDER_MODES: RenderMode[] = ['auto', 'webgl', 'canvas', 'dom'];
+  const VALID_RENDER_MODES: RenderMode[] = ['auto', 'webgpu', 'webgl', 'canvas', 'dom'];
   const isRenderMode = (value: unknown): value is RenderMode =>
     typeof value === 'string' && VALID_RENDER_MODES.includes(value as RenderMode);
 


### PR DESCRIPTION
## 变更内容

### 新增功能
- **终端触摸手势增强**（）：单指长按 500ms 弹出复制/粘贴/全选快捷菜单，单指上下滑动精准控制终端滚动
- **RDP/VNC 触摸-鼠标映射**（）：支持 Absolute（直接映射坐标）和 Relative（触控板模式）两种模式，单指 tap=左键、长按=右键、双指 tap=右键、拖拽=鼠标拖拽
- **WebGPU 渲染支持**（）：WebGPU 能力检测与 GPUDevice 管理，作为最高优先级渲染模式，不可用时自动降级到 WebGL/Canvas/DOM
- **WebCodecs 视频解码**（）：基于 WebCodecs API 的硬件加速视频解码，支持 OffscreenCanvas 离屏渲染，移动端/低端设备条件启用

### 修改文件
- ：集成 WebGPU 渲染分支
- ：接入触摸手势长按菜单 + 移动端粘贴复用 bracketed paste
- ：接入触摸鼠标映射 + WebCodecs 初始化
- ：接入触摸鼠标映射
- ：更新变更日志

### 测试情况
- 全量测试通过（2528 tests / 97 files）
- 新增 composable 单元测试通过（6 tests）
- Typecheck 零错误

### 技术说明
- WebGPU 当前仅做能力检测和设备初始化，实际渲染仍由 WebGL addon 承担（等待  成熟）
- WebCodecs composable 已就绪，Guacamole 暂未暴露 encoded video chunk 入口，当前只做条件初始化和生命周期管理
- 触摸手势使用原生 Touch 事件，未引入 hammer.js 依赖

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds mobile-focused input and rendering upgrades—terminal touch gestures, RDP/VNC touch-to-mouse, and WebGPU/WebCodecs groundwork—with safe fallbacks. Also improves resilience on mobile/low‑end devices and fixes WebGPU recovery, unintended long‑press drags, and a relative‑mode drag jump.

- **New Features**
  - Terminal touch gestures (`useTouchGestures`): 500ms long‑press menu (copy/paste/select‑all) and single‑finger vertical scroll; reuses bracketed paste.
  - RDP/VNC touch‑to‑mouse (`useTouchMouseMapping`): Absolute/Relative modes; tap/long‑press/two‑finger tap/drag map to mouse actions.
  - WebGPU support (`useWebGPURenderer`): capability check and `GPUDevice` lifecycle; prefers `webgpu` with auto fallback to WebGL/Canvas/DOM; rendering still uses the WebGL addon.
  - WebCodecs decoding (`useVideoDecoder`): hardware‑accelerated decode with `OffscreenCanvas` when available; initialized on mobile/low‑end in Remote Desktop/VNC modals; Guacamole still renders.
  - Tests: unit tests for touch gestures, touch‑mouse mapping, and appearance store `webgpu` mode; typecheck clean.

- **Bug Fixes**
  - Touch menu: clamped to viewport; closes on clipboard errors; long‑press ignored while menu is open; resets touch baseline after closing to prevent scroll jump.
  - Touch mapping: prevents unintended drags—left click is delayed until move exceeds threshold or sent on tap; releases left button on two‑finger tap; accounts for Guacamole display scale; no cursor jump after mode switch; fixed Relative‑mode drag start jump.
  - WebCodecs: cache `transferControlToOffscreen` to avoid crashes; corrected default codec; safer modal initialization.
  - WebGPU: de‑duped concurrent `initGPUDevice` calls, clears pending state for retries; added `webgpu` to appearance store render modes; context‑loss recovery now works in `webgpu` mode.

<sup>Written for commit 1c70793b361bb3a59cc1e57370aad2a6a477d371. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Silentely/nexus-terminal/pull/94?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

