### PR TITLE
Fix/hard bugs upload webrtc xterm

### DIFF
--- a/packages/backend/src/sftp/sftp-upload.manager.ts
+++ b/packages/backend/src/sftp/sftp-upload.manager.ts
@@ -310,9 +310,12 @@ export class SftpUploadManager {
     }
 
     try {
-      // 全局内存上限检查：拒绝超出总缓冲内存上限的新分块
+      // 全局内存上限检查：拒绝超出总缓冲内存上限的新分块。
+      // 重复块会覆盖 pending buffer，预算只计算净增量，避免重复计数。
       const estimatedChunkBytes = Math.ceil((dataBase64.length * 3) / 4); // base64 解码后大致字节数
-      if (globalBufferedBytes + estimatedChunkBytes > GLOBAL_UPLOAD_MEMORY_LIMIT) {
+      const previousPendingChunk = uploadState.pendingChunks.get(chunkIndex);
+      const additionalBufferedBytes = estimatedChunkBytes - (previousPendingChunk?.length ?? 0);
+      if (globalBufferedBytes + additionalBufferedBytes > GLOBAL_UPLOAD_MEMORY_LIMIT) {
         logger.warn(
           `[SFTP Upload ${uploadId}] Global buffer memory limit reached (${Math.round(globalBufferedBytes / 1024 / 1024)}MB/${Math.round(GLOBAL_UPLOAD_MEMORY_LIMIT / 1024 / 1024)}MB), rejecting chunk ${chunkIndex}.`,
         );
@@ -329,7 +332,7 @@ export class SftpUploadManager {
       }
 
       // 仅在块未重复时才计入在途计数，防止重复块耗尽滑动窗口
-      const isDuplicate = uploadState.pendingChunks.has(chunkIndex);
+      const isDuplicate = previousPendingChunk !== undefined;
       if (!isDuplicate) {
         uploadState.inFlightChunks++;
       } else {
@@ -339,7 +342,10 @@ export class SftpUploadManager {
       }
       const chunkBuffer = Buffer.from(dataBase64, 'base64');
 
-      // 跟踪全局缓冲内存
+      // 跟踪全局缓冲内存；重复块覆盖时先释放旧 buffer 的预算。
+      if (previousPendingChunk) {
+        globalBufferedBytes = Math.max(0, globalBufferedBytes - previousPendingChunk.length);
+      }
       globalBufferedBytes += chunkBuffer.length;
 
       // 将块存入排序缓冲区（不直接写入流）
@@ -516,15 +522,20 @@ export class SftpUploadManager {
     return new Promise<void>((resolveWrite, reject) => {
       let settled = false;
       let writeCallbackResolved = false;
-      let writeSuccess: boolean | undefined;
+      let drainResolved = false;
       const settle = (action: 'resolve' | 'reject', err?: Error) => {
         if (settled) return;
         settled = true;
         if (action === 'resolve') resolveWrite();
         else reject(err);
       };
+      const settleIfReady = () => {
+        if (writeCallbackResolved && drainResolved) {
+          settle('resolve');
+        }
+      };
 
-      writeSuccess = uploadState.stream.write(chunkBuffer, (err) => {
+      const writeSuccess = uploadState.stream.write(chunkBuffer, (err) => {
         if (err) {
           logger.error(`[SFTP Upload ${uploadId}] Write callback error:`, err);
           sendWsMessage(
@@ -548,16 +559,12 @@ export class SftpUploadManager {
           logger.warn('[SFTP Upload] 指标模块加载失败，上传字节未记录:', metricsErr);
         }
 
-        // 回调表示写入已完成；如果 write() 返回 false，仍需等待 drain 再 resolve。
-        queueMicrotask(() => {
-          if (writeSuccess !== false) {
-            settle('resolve');
-          }
-        });
+        // write callback 表示远端确认写入；write() 返回 false 时还需确认 drain 已释放背压。
+        queueMicrotask(settleIfReady);
       });
 
       if (writeSuccess === false) {
-        // 背压：等 drain 事件后再 resolve（回调中 bytesWritten 已更新）
+        // 背压：drain 和 write callback 都到达后再 resolve，避免任意事件先到导致挂起。
         if (!uploadState.drainPromise) {
           uploadState.drainPromise = new Promise<void>((drainResolve) => {
             uploadState.stream.once('drain', () => {
@@ -567,8 +574,12 @@ export class SftpUploadManager {
           });
         }
         uploadState.drainPromise.then(() => {
-          if (writeCallbackResolved) settle('resolve');
+          drainResolved = true;
+          settleIfReady();
         });
+      } else {
+        drainResolved = true;
+        queueMicrotask(settleIfReady);
       }
     });
   }

--- a/packages/backend/src/sftp/sftp-upload.manager.ts
+++ b/packages/backend/src/sftp/sftp-upload.manager.ts
@@ -423,6 +423,7 @@ export class SftpUploadManager {
             state.ws,
             'sftp:upload:progress',
             {
+              uploadId,
               bytesWritten: uploadState.bytesWritten,
               totalSize: uploadState.totalSize,
               progress: Math.min(100, progressPercent),
@@ -435,7 +436,7 @@ export class SftpUploadManager {
           sendWsMessage(
             state.ws,
             'sftp:upload:chunk:ack',
-            { chunkIndex: currentIndex, windowSlots },
+            { uploadId, chunkIndex: currentIndex, windowSlots },
             uploadState.sessionId,
           );
         }
@@ -514,6 +515,8 @@ export class SftpUploadManager {
 
     return new Promise<void>((resolveWrite, reject) => {
       let settled = false;
+      let writeCallbackResolved = false;
+      let writeSuccess: boolean | undefined;
       const settle = (action: 'resolve' | 'reject', err?: Error) => {
         if (settled) return;
         settled = true;
@@ -521,7 +524,7 @@ export class SftpUploadManager {
         else reject(err);
       };
 
-      const writeSuccess = uploadState.stream.write(chunkBuffer, (err) => {
+      writeSuccess = uploadState.stream.write(chunkBuffer, (err) => {
         if (err) {
           logger.error(`[SFTP Upload ${uploadId}] Write callback error:`, err);
           sendWsMessage(
@@ -536,6 +539,7 @@ export class SftpUploadManager {
         }
 
         uploadState.bytesWritten += chunkBuffer.length;
+        writeCallbackResolved = true;
         // SFTP 上传字节指标（延迟导入避免循环依赖）
         try {
           const { sftpTransferredBytes } = require('../metrics/metrics.service');
@@ -544,14 +548,15 @@ export class SftpUploadManager {
           logger.warn('[SFTP Upload] 指标模块加载失败，上传字节未记录:', metricsErr);
         }
 
-        if (writeSuccess) {
-          // 内核缓冲区尚有余量，回调即表示数据已入队
-          settle('resolve');
-        }
-        // writeSuccess === false 时不在此 resolve，等 drain
+        // 回调表示写入已完成；如果 write() 返回 false，仍需等待 drain 再 resolve。
+        queueMicrotask(() => {
+          if (writeSuccess !== false) {
+            settle('resolve');
+          }
+        });
       });
 
-      if (!writeSuccess) {
+      if (writeSuccess === false) {
         // 背压：等 drain 事件后再 resolve（回调中 bytesWritten 已更新）
         if (!uploadState.drainPromise) {
           uploadState.drainPromise = new Promise<void>((drainResolve) => {
@@ -561,7 +566,9 @@ export class SftpUploadManager {
             });
           });
         }
-        uploadState.drainPromise.then(() => settle('resolve'));
+        uploadState.drainPromise.then(() => {
+          if (writeCallbackResolved) settle('resolve');
+        });
       }
     });
   }

--- a/packages/backend/src/sftp/sftp.service.test.ts
+++ b/packages/backend/src/sftp/sftp.service.test.ts
@@ -1094,6 +1094,52 @@ describe('SftpService', () => {
       expect(mockWs.send).toHaveBeenCalledWith(expect.stringContaining('sftp:upload:ready'));
     });
 
+    it('上传分块确认和进度消息应包含 uploadId', async () => {
+      const mockWriteStream = new MockWriteStream();
+      const openHandle = {};
+
+      mockSftp.open.mockImplementation((path: string, flags: string, callback: unknown) => {
+        callback(null, openHandle);
+      });
+      mockSftp.close.mockImplementation((handle: unknown, callback: unknown) => {
+        callback(null);
+      });
+      mockSftp.stat.mockImplementation((path: string, callback: unknown) => {
+        callback(null, { mode: 0o100755 });
+      });
+      mockSftp.createWriteStream.mockReturnValue(mockWriteStream);
+      mockWriteStream.write.mockImplementation(
+        (_chunk: Buffer, callback: (err?: Error) => void) => {
+          callback();
+          return true;
+        },
+      );
+
+      await service.startUpload(sessionId, uploadId, remotePath, totalSize);
+      mockWs.send.mockClear();
+
+      await service.handleUploadChunk(
+        sessionId,
+        uploadId,
+        0,
+        Buffer.from('hello').toString('base64'),
+      );
+
+      const sentMessages = mockWs.send.mock.calls.map(([raw]) => JSON.parse(raw as string));
+      expect(sentMessages).toContainEqual(
+        expect.objectContaining({
+          type: 'sftp:upload:progress',
+          payload: expect.objectContaining({ uploadId }),
+        }),
+      );
+      expect(sentMessages).toContainEqual(
+        expect.objectContaining({
+          type: 'sftp:upload:chunk:ack',
+          payload: expect.objectContaining({ uploadId, chunkIndex: 0 }),
+        }),
+      );
+    });
+
     it('SFTP 未就绪时应发送错误', async () => {
       clientStates.set(sessionId, {
         sshClient: mockSshClient,

--- a/packages/backend/src/sftp/sftp.service.test.ts
+++ b/packages/backend/src/sftp/sftp.service.test.ts
@@ -1140,6 +1140,85 @@ describe('SftpService', () => {
       );
     });
 
+    it('背压 drain 先于 write callback 时上传分块不应挂起', async () => {
+      const mockWriteStream = new MockWriteStream();
+      const openHandle = {};
+      let writeCallback: ((err?: Error) => void) | undefined;
+
+      mockSftp.open.mockImplementation((path: string, flags: string, callback: unknown) => {
+        callback(null, openHandle);
+      });
+      mockSftp.close.mockImplementation((handle: unknown, callback: unknown) => {
+        callback(null);
+      });
+      mockSftp.stat.mockImplementation((path: string, callback: unknown) => {
+        callback(null, { mode: 0o100755 });
+      });
+      mockSftp.createWriteStream.mockReturnValue(mockWriteStream);
+      mockWriteStream.write.mockImplementation(
+        (_chunk: Buffer, callback: (err?: Error) => void) => {
+          writeCallback = callback;
+          return false;
+        },
+      );
+
+      await service.startUpload(sessionId, uploadId, remotePath, totalSize);
+      mockWs.send.mockClear();
+
+      const uploadPromise = service.handleUploadChunk(
+        sessionId,
+        uploadId,
+        0,
+        Buffer.from('hello').toString('base64'),
+      );
+
+      mockWriteStream.emit('drain');
+      const beforeCallback = await Promise.race([
+        uploadPromise.then(() => 'resolved'),
+        new Promise((resolve) => setTimeout(() => resolve('pending'), 10)),
+      ]);
+      expect(beforeCallback).toBe('pending');
+
+      writeCallback?.();
+      await expect(uploadPromise).resolves.toBeUndefined();
+      expect(mockWs.send).toHaveBeenCalledWith(expect.stringContaining('sftp:upload:chunk:ack'));
+    });
+
+    it('写入失败时应发送错误并拒绝分块处理', async () => {
+      const mockWriteStream = new MockWriteStream();
+      const openHandle = {};
+
+      mockSftp.open.mockImplementation((path: string, flags: string, callback: unknown) => {
+        callback(null, openHandle);
+      });
+      mockSftp.close.mockImplementation((handle: unknown, callback: unknown) => {
+        callback(null);
+      });
+      mockSftp.stat.mockImplementation((path: string, callback: unknown) => {
+        callback(null, { mode: 0o100755 });
+      });
+      mockSftp.createWriteStream.mockReturnValue(mockWriteStream);
+      mockWriteStream.write.mockImplementation(
+        (_chunk: Buffer, callback: (err?: Error) => void) => {
+          callback(new Error('Write failed'));
+          return false;
+        },
+      );
+
+      await service.startUpload(sessionId, uploadId, remotePath, totalSize);
+      mockWs.send.mockClear();
+
+      await service.handleUploadChunk(
+        sessionId,
+        uploadId,
+        0,
+        Buffer.from('fail').toString('base64'),
+      );
+
+      expect(mockWs.send).toHaveBeenCalledWith(expect.stringContaining('sftp:upload:error'));
+      expect(mockWs.send).toHaveBeenCalledWith(expect.stringContaining('Write failed'));
+    });
+
     it('SFTP 未就绪时应发送错误', async () => {
       clientStates.set(sessionId, {
         sshClient: mockSshClient,

--- a/packages/backend/src/webrtc/bridge.ts
+++ b/packages/backend/src/webrtc/bridge.ts
@@ -37,6 +37,28 @@ function isInternalGatewayUrl(url: string): boolean {
  */
 const CLIENT_HANDSHAKE_FILTER = /^(connect|select|size|audio|video|image|timezone)[,;]/;
 
+function getRemoteGatewayWsBaseUrl(): string {
+  const deploymentMode = process.env.DEPLOYMENT_MODE;
+  if (deploymentMode === 'local') {
+    return process.env.REMOTE_GATEWAY_WS_URL_LOCAL || 'ws://localhost:8081';
+  }
+  if (deploymentMode === 'docker') {
+    return process.env.REMOTE_GATEWAY_WS_URL_DOCKER || 'ws://remote-gateway:8081';
+  }
+  return 'ws://localhost:8081';
+}
+
+function resolveRemoteGatewayUrl(remoteGatewayUrl: string): string {
+  const incomingUrl = new URL(remoteGatewayUrl);
+  const gatewayBaseUrl = new URL(getRemoteGatewayWsBaseUrl());
+
+  gatewayBaseUrl.search = incomingUrl.search;
+  gatewayBaseUrl.hash = '';
+  gatewayBaseUrl.pathname = '/';
+
+  return gatewayBaseUrl.toString();
+}
+
 /**
  * 桥接 WebRTC DataChannel 到 remote-gateway WebSocket
  * @param dc WebRTC DataChannel（浏览器侧）
@@ -56,16 +78,30 @@ export async function bridgeDataChannelToGateway(
     return;
   }
 
+  let gatewayUrl: string;
+  try {
+    gatewayUrl = resolveRemoteGatewayUrl(remoteGatewayUrl);
+  } catch (error) {
+    logger.error(`[WebRTC Bridge] remoteGatewayUrl 无效: ${sessionId}`, error);
+    dc.send(
+      JSON.stringify({
+        type: 'error',
+        payload: `remote-gateway URL 无效: ${error instanceof Error ? error.message : '未知错误'}`,
+      }),
+    );
+    return;
+  }
+
   // SSRF 防护：内部网关地址直接放行，外部地址需 DNS 验证 + 绑定
   let agent: http.Agent | undefined;
-  if (!isInternalGatewayUrl(remoteGatewayUrl)) {
+  if (!isInternalGatewayUrl(gatewayUrl)) {
     try {
       const { addresses } = await resolveAndValidatePublicHost(
-        remoteGatewayUrl,
+        gatewayUrl,
         `WebRTC-Bridge-${sessionId}`,
       );
       const lookup = createPinnedLookup(addresses);
-      const urlObj = new URL(remoteGatewayUrl);
+      const urlObj = new URL(gatewayUrl);
       agent = urlObj.protocol === 'wss:' ? new https.Agent({ lookup }) : new http.Agent({ lookup });
     } catch (error) {
       logger.error(`[WebRTC Bridge] SSRF 验证失败: ${sessionId}`, error);
@@ -80,7 +116,7 @@ export async function bridgeDataChannelToGateway(
   }
 
   // 连接到 remote-gateway（DNS pinning 消除 TOCTOU 竞态）
-  const gatewayWs = new WebSocket(remoteGatewayUrl, { agent });
+  const gatewayWs = new WebSocket(gatewayUrl, { agent });
   let gatewayReady = false;
   let dcClosed = false;
   let gwClosed = false;

--- a/packages/backend/src/webrtc/signaling.test.ts
+++ b/packages/backend/src/webrtc/signaling.test.ts
@@ -2,7 +2,7 @@
  * WebRTC 信令 — getICEConfig 单元测试
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { getICEConfig } from './signaling';
+import { getICEConfig, getWeriftICEConfig } from './signaling';
 
 describe('getICEConfig', () => {
   const originalEnv = process.env;
@@ -112,5 +112,23 @@ describe('getICEConfig', () => {
     const config = getICEConfig();
 
     expect(config.iceServers).toHaveLength(1);
+  });
+
+  it('应将多个 ICE URL 展开为 werift 支持的单 URL 条目', () => {
+    process.env.WEBRTC_STUN_URLS = 'stun:a.example.com:3478,stun:b.example.com:3478';
+    process.env.WEBRTC_TURN_URLS = 'turn:turn.example.com:3478';
+    process.env.WEBRTC_TURN_USERNAME = 'user';
+    process.env.WEBRTC_TURN_CREDENTIAL = 'pass';
+
+    const config = getWeriftICEConfig();
+
+    expect(config).toEqual([
+      { urls: 'stun:a.example.com:3478', username: undefined, credential: undefined },
+      { urls: 'stun:b.example.com:3478', username: undefined, credential: undefined },
+      { urls: 'turn:turn.example.com:3478', username: 'user', credential: 'pass' },
+    ]);
+    expect(config.map((server) => server.urls)).not.toContain(
+      'stun:a.example.com:3478,stun:b.example.com:3478',
+    );
   });
 });

--- a/packages/backend/src/webrtc/signaling.ts
+++ b/packages/backend/src/webrtc/signaling.ts
@@ -45,6 +45,12 @@ interface ActiveWebRTCSession {
   createdAt: number;
 }
 
+type WeriftIceServer = {
+  urls: string;
+  username?: string;
+  credential?: string;
+};
+
 /** 活跃会话映射 (sessionId -> session) */
 const activeSessions = new Map<string, ActiveWebRTCSession>();
 
@@ -79,6 +85,18 @@ export function getICEConfig(): WebRTCConfig {
   }
 
   return { iceServers };
+}
+
+export function getWeriftICEConfig(): WeriftIceServer[] {
+  return getICEConfig().iceServers.flatMap((server) => {
+    const urls = Array.isArray(server.urls) ? server.urls : [server.urls];
+
+    return urls.map((url) => ({
+      urls: url,
+      username: server.username,
+      credential: server.credential,
+    }));
+  });
 }
 
 /**
@@ -158,17 +176,10 @@ async function handleOffer(
   }
 
   const sessionId = `webrtc-${Date.now()}-${crypto.randomBytes(4).toString('hex')}`;
-  const iceConfig = getICEConfig();
+  const iceServers = getWeriftICEConfig();
 
   // 创建 RTCPeerConnection
-  const pc = new RTCPeerConnection({
-    iceServers: iceConfig.iceServers.map((server) => ({
-      // werift 类型定义仅接受 string，数组需转为逗号分隔
-      urls: Array.isArray(server.urls) ? server.urls.join(',') : server.urls,
-      username: server.username,
-      credential: server.credential,
-    })),
-  });
+  const pc = new RTCPeerConnection({ iceServers });
 
   const session: ActiveWebRTCSession = {
     pc,

--- a/packages/backend/src/websocket/rate-limiter.test.ts
+++ b/packages/backend/src/websocket/rate-limiter.test.ts
@@ -99,18 +99,22 @@ describe('WebSocket 速率限制器', () => {
       expect(checkRateLimit('session-1', 'batch:create')).toBe(false);
     });
 
-    it('多文件上传启动允许 100 条/秒', () => {
+    it('多文件上传启动仍保留普通消息限流并在窗口重置后恢复', () => {
       for (let i = 0; i < 100; i++) {
         expect(checkRateLimit('session-1', 'sftp:upload:start')).toBe(true);
       }
       expect(checkRateLimit('session-1', 'sftp:upload:start')).toBe(false);
+
+      vi.advanceTimersByTime(1001);
+      expect(checkRateLimit('session-1', 'sftp:upload:start')).toBe(true);
     });
 
-    it('上传分块允许 1000 条/秒以支持批量上传滑动窗口', () => {
-      for (let i = 0; i < 1000; i++) {
+    it('上传分块交给 SFTP 上传管理器控制，不受普通消息频率误伤', () => {
+      for (let i = 0; i < 5000; i++) {
         expect(checkRateLimit('session-1', 'sftp:upload:chunk')).toBe(true);
       }
-      expect(checkRateLimit('session-1', 'sftp:upload:chunk')).toBe(false);
+
+      expect(getRateLimitStatus('session-1')['sftp:upload:chunk']).toBeUndefined();
     });
   });
 

--- a/packages/backend/src/websocket/rate-limiter.test.ts
+++ b/packages/backend/src/websocket/rate-limiter.test.ts
@@ -98,6 +98,20 @@ describe('WebSocket 速率限制器', () => {
       }
       expect(checkRateLimit('session-1', 'batch:create')).toBe(false);
     });
+
+    it('多文件上传启动允许 100 条/秒', () => {
+      for (let i = 0; i < 100; i++) {
+        expect(checkRateLimit('session-1', 'sftp:upload:start')).toBe(true);
+      }
+      expect(checkRateLimit('session-1', 'sftp:upload:start')).toBe(false);
+    });
+
+    it('上传分块允许 1000 条/秒以支持批量上传滑动窗口', () => {
+      for (let i = 0; i < 1000; i++) {
+        expect(checkRateLimit('session-1', 'sftp:upload:chunk')).toBe(true);
+      }
+      expect(checkRateLimit('session-1', 'sftp:upload:chunk')).toBe(false);
+    });
   });
 
   describe('cleanupRateLimit', () => {

--- a/packages/backend/src/websocket/rate-limiter.ts
+++ b/packages/backend/src/websocket/rate-limiter.ts
@@ -42,10 +42,11 @@ const RATE_LIMITS: Record<string, RateLimitConfig> = {
   'sftp:rmdir': { maxMessages: 10, windowMs: 1000 },
   'sftp:unlink': { maxMessages: 10, windowMs: 1000 },
   'sftp:rename': { maxMessages: 10, windowMs: 1000 },
-  // 大文件分块上传：前端可能高频发送分块，阈值较高
-  'sftp:upload:chunk': { maxMessages: 200, windowMs: 1000 },
-  // 上传启动：管理类操作，限制严格
-  'sftp:upload:start': { maxMessages: 10, windowMs: 1000 },
+  // 大文件/多文件分块上传：真实批量上传会按每文件滑动窗口并发发送，
+  // 安全性主要由 SftpUploadManager 的每上传窗口和全局缓冲上限控制。
+  'sftp:upload:chunk': { maxMessages: 1000, windowMs: 1000 },
+  // 多文件/目录上传会瞬间启动多个文件任务，需避免误伤正常批量上传。
+  'sftp:upload:start': { maxMessages: 100, windowMs: 1000 },
   'sftp:upload:cancel': { maxMessages: 10, windowMs: 1000 },
 
   // Docker 操作：轮询 Docker API，限制严格

--- a/packages/backend/src/websocket/rate-limiter.ts
+++ b/packages/backend/src/websocket/rate-limiter.ts
@@ -8,6 +8,13 @@
 
 import { logger } from '../utils/logger';
 
+/**
+ * 上传分块是数据流量，不适合用普通 WebSocket 消息频率限流。
+ * 真正的上传压力由 SftpUploadManager 的每上传滑动窗口、chunk 大小校验、
+ * pending buffer 与全局内存预算控制；这里豁免可避免目录/多文件上传被误伤。
+ */
+const PROTOCOL_MANAGED_MESSAGE_TYPES = new Set(['sftp:upload:chunk']);
+
 /** 速率限制配置 */
 interface RateLimitConfig {
   /** 窗口内最大消息数 */
@@ -42,10 +49,8 @@ const RATE_LIMITS: Record<string, RateLimitConfig> = {
   'sftp:rmdir': { maxMessages: 10, windowMs: 1000 },
   'sftp:unlink': { maxMessages: 10, windowMs: 1000 },
   'sftp:rename': { maxMessages: 10, windowMs: 1000 },
-  // 大文件/多文件分块上传：真实批量上传会按每文件滑动窗口并发发送，
-  // 安全性主要由 SftpUploadManager 的每上传窗口和全局缓冲上限控制。
-  'sftp:upload:chunk': { maxMessages: 1000, windowMs: 1000 },
   // 多文件/目录上传会瞬间启动多个文件任务，需避免误伤正常批量上传。
+  // 真正的分块吞吐压力由 SftpUploadManager 的 per-upload sliding window 和全局缓冲上限控制。
   'sftp:upload:start': { maxMessages: 100, windowMs: 1000 },
   'sftp:upload:cancel': { maxMessages: 10, windowMs: 1000 },
 
@@ -106,6 +111,11 @@ if (cleanupTimer.unref) {
  * @returns true = 允许，false = 超过限制
  */
 export function checkRateLimit(sessionId: string, messageType: string): boolean {
+  if (PROTOCOL_MANAGED_MESSAGE_TYPES.has(messageType)) {
+    sessionLastActivity.set(sessionId, Date.now());
+    return true;
+  }
+
   const config = RATE_LIMITS[messageType] || RATE_LIMITS._default;
   const now = Date.now();
 

--- a/packages/frontend/src/composables/terminal/useTerminalRenderer.ts
+++ b/packages/frontend/src/composables/terminal/useTerminalRenderer.ts
@@ -381,17 +381,22 @@ export function useTerminalRenderer(terminal: Ref<Terminal | null>, sessionId: s
    */
   function cleanup(): void {
     stopMonitoring();
-    if (terminal.value) {
-      disposeWebglAddon();
-      disposeWebGPU();
-    } else {
-      webglAddonInstance = null;
-    }
+    disposeWebglAddon();
+    disposeWebGPU();
+    contextState.value = 'unavailable';
+  }
+
+  function cleanupBeforeTerminalDispose(): void {
+    stopMonitoring();
+    disposeWebGPU();
+    webglAddonInstance = null;
     contextState.value = 'unavailable';
   }
 
   onBeforeUnmount(() => {
-    cleanup();
+    // Terminal.vue disposes the xterm instance on unmount. xterm will dispose loaded addons;
+    // do not manually dispose WebglAddon here or xterm may attempt to dispose it twice.
+    cleanupBeforeTerminalDispose();
   });
 
   return {

--- a/packages/frontend/src/composables/useFileUploader.test.ts
+++ b/packages/frontend/src/composables/useFileUploader.test.ts
@@ -174,6 +174,42 @@ describe('useFileUploader', () => {
         }),
       );
     });
+
+    it('文件夹多文件上传应排队启动，完成后自动补位', async () => {
+      const sessionId = ref('s1');
+      const currentPath = ref('/home');
+      const fileList = ref([]) as any;
+      const handlers = new Map<string, Function>();
+      const wsDeps = makeWsDeps({
+        onMessage: vi.fn((type: string, handler: Function) => {
+          handlers.set(type, handler);
+          return vi.fn();
+        }),
+      });
+
+      const { uploads, startFileUpload } = useFileUploader(
+        sessionId,
+        currentPath,
+        fileList,
+        wsDeps,
+      );
+
+      for (let i = 0; i < 10; i++) {
+        startFileUpload(makeFile(`file-${i}.txt`));
+      }
+
+      expect(Object.keys(uploads)).toHaveLength(10);
+      expect(wsDeps.value.sendMessage).toHaveBeenCalledTimes(8);
+
+      const firstUploadId = Object.keys(uploads)[0];
+      handlers.get('sftp:upload:success')?.(
+        { uploadId: firstUploadId },
+        { type: 'sftp:upload:success' },
+      );
+      await Promise.resolve();
+
+      expect(wsDeps.value.sendMessage).toHaveBeenCalledTimes(9);
+    });
   });
 
   describe('cancelUpload', () => {

--- a/packages/frontend/src/composables/useFileUploader.ts
+++ b/packages/frontend/src/composables/useFileUploader.ts
@@ -18,6 +18,14 @@ const joinPath = (base: string, name: string): string => {
   return `${base}/${name}`;
 };
 
+const MAX_ACTIVE_UPLOAD_STARTS = 8;
+
+type QueuedUploadItem = UploadItem & {
+  remotePath: string;
+  relativePath?: string;
+  startRequested?: boolean;
+};
+
 export function useFileUploader(
   sessionIdForLog: Ref<string>,
   currentPathRef: Ref<string>,
@@ -36,6 +44,50 @@ export function useFileUploader(
     wsDeps,
     sessionIdForLog,
     t,
+  };
+
+  const activeUploadStartCount = (): number =>
+    Object.values(uploads).filter(
+      (upload) =>
+        (upload as QueuedUploadItem).startRequested &&
+        ['pending', 'uploading', 'paused'].includes(upload.status),
+    ).length;
+
+  const sendUploadStart = (uploadId: string, upload: QueuedUploadItem): void => {
+    const queuedUpload = uploads[uploadId] as QueuedUploadItem | undefined;
+    if (!queuedUpload) return;
+    queuedUpload.startRequested = true;
+    log.info(
+      `[FileUploader ${sessionIdForLog.value}] Starting upload ${uploadId} to ${upload.remotePath}`,
+    );
+    wsDeps.value.sendMessage({
+      type: 'sftp:upload:start',
+      payload: {
+        uploadId,
+        remotePath: upload.remotePath,
+        size: upload.file.size,
+        relativePath: upload.relativePath,
+      },
+    });
+  };
+
+  const pumpUploadStartQueue = (): void => {
+    if (!wsDeps.value.isConnected.value) return;
+
+    let availableSlots = Math.max(0, MAX_ACTIVE_UPLOAD_STARTS - activeUploadStartCount());
+    if (availableSlots === 0) return;
+
+    for (const [uploadId, upload] of Object.entries(uploads) as Array<[string, QueuedUploadItem]>) {
+      if (availableSlots <= 0) break;
+      if (upload.status === 'pending' && !upload.startRequested) {
+        sendUploadStart(uploadId, upload);
+        availableSlots--;
+      }
+    }
+  };
+
+  const releaseUploadStartSlot = (): void => {
+    queueMicrotask(pumpUploadStartQueue);
   };
 
   const startFileUpload = (file: File, relativePath?: string) => {
@@ -91,20 +143,12 @@ export function useFileUploader(
       progress: 0,
       sentBytes: 0,
       status: 'pending', // 初始状态
-    };
+      remotePath: finalRemotePath,
+      relativePath: relativePath || undefined,
+      startRequested: false,
+    } as QueuedUploadItem;
 
-    log.info(
-      `[FileUploader ${sessionIdForLog.value}] Starting upload ${uploadId} to ${finalRemotePath}`,
-    );
-    wsDeps.value.sendMessage({
-      type: 'sftp:upload:start',
-      payload: {
-        uploadId,
-        remotePath: finalRemotePath,
-        size: file.size,
-        relativePath: relativePath || undefined,
-      },
-    });
+    pumpUploadStartQueue();
     // 后端应该响应 sftp:upload:ready
   };
 
@@ -121,9 +165,12 @@ export function useFileUploader(
         uploadWithAck._unregisterAck = undefined;
       }
 
-      if (notifyBackend && wsDeps.value.isConnected.value) {
+      const uploadWithQueue = upload as QueuedUploadItem;
+      if (notifyBackend && uploadWithQueue.startRequested && wsDeps.value.isConnected.value) {
         wsDeps.value.sendMessage({ type: 'sftp:upload:cancel', payload: { uploadId } });
       }
+
+      releaseUploadStartSlot();
 
       // 短暂延迟后从列表中移除，以显示取消状态
       setTimeout(() => {
@@ -179,6 +226,7 @@ export function useFileUploader(
       if (uploads[uploadId]) {
         delete uploads[uploadId];
       }
+      releaseUploadStartSlot();
     } else {
       log.warn(
         `[FileUploader ${sessionIdForLog.value}] Received upload:success for unknown upload ID: ${uploadId}`,
@@ -221,6 +269,7 @@ export function useFileUploader(
       }
 
       // 让错误消息可见时间长一些
+      releaseUploadStartSlot();
       setTimeout(() => {
         if (uploads[uploadId]?.status === 'error') {
           delete uploads[uploadId];
@@ -279,6 +328,7 @@ export function useFileUploader(
       }
 
       // 确保它会被移除（如果尚未计划移除）
+      releaseUploadStartSlot();
       setTimeout(() => {
         if (uploads[uploadId]?.status === 'cancelled') {
           delete uploads[uploadId];

--- a/packages/frontend/src/composables/useSftpActions.test.ts
+++ b/packages/frontend/src/composables/useSftpActions.test.ts
@@ -768,6 +768,28 @@ describe('useSftpActions (createSftpActionsManager)', () => {
       expect(mockShowSuccess).toHaveBeenCalled();
     });
 
+    it('压缩点号开头的单文件时应保留完整文件名作为归档名', async () => {
+      const manager = createSftpActionsManager('session-1', currentPathRef, createWsDeps(), mockT);
+
+      const compressPromise = manager.compressItems([createFileItem('.env')], 'zip');
+
+      expect(mockSendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'sftp:compress',
+          payload: expect.objectContaining({
+            sources: ['/home/user/.env'],
+            destination: '/home/user/.env.zip',
+            format: 'zip',
+          }),
+        }),
+      );
+
+      const requestId = (mockSendMessage.mock.calls[0][0] as any).requestId;
+      triggerMessage('sftp:compress:success', {}, { requestId });
+
+      await compressPromise;
+    });
+
     it('SFTP 未就绪时应拒绝 Promise', async () => {
       mockIsSftpReady.value = false;
       const manager = createSftpActionsManager('session-1', currentPathRef, createWsDeps(), mockT);

--- a/packages/frontend/src/composables/useSftpOperations.ts
+++ b/packages/frontend/src/composables/useSftpOperations.ts
@@ -34,8 +34,16 @@ const generateRequestId = (): string =>
 
 /** 拼接路径 */
 const joinPath = (base: string, name: string): string => {
-  if (base === '/') return `/${name}`;
+  if (!base || base === '/') return `/${name}`;
   return base.endsWith('/') ? `${base}${name}` : `${base}/${name}`;
+};
+
+const getArchiveBaseName = (filename: string): string => {
+  const lastDotIndex = filename.lastIndexOf('.');
+  if (lastDotIndex <= 0) {
+    return filename || 'archive';
+  }
+  return filename.slice(0, lastDotIndex) || filename;
 };
 
 /**
@@ -335,7 +343,7 @@ export function createSftpOperations(deps: SftpOperationsDeps) {
       const parentDir = currentPathRef.value;
       let archiveBaseName = 'archive';
       if (items.length === 1) {
-        archiveBaseName = items[0].filename.split('.')[0];
+        archiveBaseName = getArchiveBaseName(items[0].filename);
       } else if (items.length > 1) {
         const parentFolderName = parentDir.split('/').pop();
         if (parentFolderName && parentFolderName !== 'root' && parentFolderName !== '') {

--- a/packages/frontend/src/composables/useUploadChunkManager.test.ts
+++ b/packages/frontend/src/composables/useUploadChunkManager.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { ref } from 'vue';
+import { sendFileChunks, type ChunkManagerDeps } from './useUploadChunkManager';
+import type { UploadItem } from '../types/upload.types';
+
+vi.mock('@/utils/log', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+class MockFileReader {
+  onload: ((event: { target: { result: string } }) => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  readAsDataURL(blob: Blob): void {
+    void blob.arrayBuffer().then((buffer) => {
+      const base64 = Buffer.from(buffer).toString('base64');
+      this.onload?.({ target: { result: `data:application/octet-stream;base64,${base64}` } });
+    });
+  }
+}
+
+describe('sendFileChunks', () => {
+  const OriginalFileReader = globalThis.FileReader;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    globalThis.FileReader = MockFileReader as unknown as typeof FileReader;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    globalThis.FileReader = OriginalFileReader;
+    vi.restoreAllMocks();
+  });
+
+  it('发送分块后应立即更新乐观进度', async () => {
+    const file = new File([new Uint8Array(512 * 1024)], 'large.bin');
+    const uploads: Record<string, UploadItem> = {
+      'upload-1': {
+        id: 'upload-1',
+        file,
+        filename: 'large.bin',
+        progress: 0,
+        sentBytes: 0,
+        status: 'uploading',
+      },
+    };
+    const sendMessage = vi.fn();
+    const deps: ChunkManagerDeps = {
+      uploads,
+      sessionIdForLog: ref('session-1'),
+      t: (key: string) => key,
+      wsDeps: ref({
+        isConnected: { value: true },
+        isSftpReady: { value: true },
+        sendMessage,
+        onMessage: vi.fn().mockReturnValue(vi.fn()),
+      } as any),
+    };
+
+    sendFileChunks(deps, 'upload-1', file);
+    await vi.runAllTimersAsync();
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'sftp:upload:chunk' }),
+    );
+    expect(uploads['upload-1'].sentBytes).toBeGreaterThan(0);
+    expect(uploads['upload-1'].progress).toBeGreaterThan(0);
+  });
+});

--- a/packages/frontend/src/composables/useUploadChunkManager.ts
+++ b/packages/frontend/src/composables/useUploadChunkManager.ts
@@ -101,6 +101,10 @@ export function sendFileChunks(
         // 乐观进度：发送后立即更新已发送字节数，提供即时进度反馈
         if (currentUpload) {
           currentUpload.sentBytes = Math.min(currentUpload.sentBytes + currentChunkSize, file.size);
+          currentUpload.progress =
+            file.size > 0
+              ? Math.min(100, Math.round((currentUpload.sentBytes / file.size) * 100))
+              : 100;
         }
       } else {
         log.error(

--- a/packages/frontend/src/composables/useWebRTCTunnel.test.ts
+++ b/packages/frontend/src/composables/useWebRTCTunnel.test.ts
@@ -1,9 +1,22 @@
 import { describe, expect, it } from 'vitest';
-import { DEFAULT_WEBRTC_CONNECT_TIMEOUT_MS, useWebRTCTunnel } from './useWebRTCTunnel';
+import {
+  DEFAULT_WEBRTC_CONNECT_TIMEOUT_MS,
+  WebRTCTunnel,
+  useWebRTCTunnel,
+} from './useWebRTCTunnel';
 
 describe('useWebRTCTunnel', () => {
   it('默认连接超时应长于后端 remote-gateway 连接窗口', () => {
     expect(DEFAULT_WEBRTC_CONNECT_TIMEOUT_MS).toBeGreaterThan(15_000);
+  });
+
+  it('WebRTCTunnel 默认配置应使用共享连接超时常量', () => {
+    const tunnel = new WebRTCTunnel({
+      signalingUrl: 'ws://backend/ws/webrtc-signaling',
+      tunnelUrl: 'ws://backend/ws/rdp-proxy?token=test',
+    }) as unknown as { config: { connectTimeout: number } };
+
+    expect(tunnel.config.connectTimeout).toBe(DEFAULT_WEBRTC_CONNECT_TIMEOUT_MS);
   });
 
   it('应导出 WebRTC tunnel 工厂函数', () => {

--- a/packages/frontend/src/composables/useWebRTCTunnel.test.ts
+++ b/packages/frontend/src/composables/useWebRTCTunnel.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_WEBRTC_CONNECT_TIMEOUT_MS, useWebRTCTunnel } from './useWebRTCTunnel';
+
+describe('useWebRTCTunnel', () => {
+  it('默认连接超时应长于后端 remote-gateway 连接窗口', () => {
+    expect(DEFAULT_WEBRTC_CONNECT_TIMEOUT_MS).toBeGreaterThan(15_000);
+  });
+
+  it('应导出 WebRTC tunnel 工厂函数', () => {
+    const { createTunnel, isWebRTCSupported, getDefaultICEConfig } = useWebRTCTunnel();
+
+    expect(createTunnel).toEqual(expect.any(Function));
+    expect(isWebRTCSupported).toEqual(expect.any(Function));
+    expect(Array.isArray(getDefaultICEConfig())).toBe(true);
+  });
+});

--- a/packages/frontend/src/composables/useWebRTCTunnel.ts
+++ b/packages/frontend/src/composables/useWebRTCTunnel.ts
@@ -41,6 +41,10 @@ export interface WebRTCTunnelConfig {
   connectTimeout?: number;
 }
 
+// 前端超时不应短于后端 bridge.ts 中 remote-gateway 的 15s 连接窗口。
+// 否则 RDP/guacd 握手稍慢时，前端会先行超时并过早回退到 WebSocket。
+export const DEFAULT_WEBRTC_CONNECT_TIMEOUT_MS = 16_000;
+
 /** 连接状态 */
 type TunnelState = 'idle' | 'signaling' | 'connected' | 'failed' | 'disconnected';
 
@@ -91,7 +95,7 @@ export class WebRTCTunnel {
         { urls: 'stun:stun.chat.bilibili.com:3478' },
         { urls: 'stun:stun.miwifi.com:3478' },
       ],
-      connectTimeout: config.connectTimeout || 10000,
+      connectTimeout: config.connectTimeout || DEFAULT_WEBRTC_CONNECT_TIMEOUT_MS,
     };
   }
 

--- a/packages/frontend/src/composables/useWebRTCTunnel.ts
+++ b/packages/frontend/src/composables/useWebRTCTunnel.ts
@@ -623,7 +623,7 @@ export function useWebRTCTunnel() {
         signalingUrl,
         tunnelUrl,
         iceServers: rtcConfig?.iceServers,
-        connectTimeout: 8000,
+        connectTimeout: DEFAULT_WEBRTC_CONNECT_TIMEOUT_MS,
       });
 
       try {

--- a/packages/frontend/src/features/terminal/Terminal.test.ts
+++ b/packages/frontend/src/features/terminal/Terminal.test.ts
@@ -65,13 +65,31 @@ vi.mock('@xterm/addon-webgl', () => ({
   })),
 }));
 
+const { mockOutputEnhancerActivate, mockOutputEnhancerDispose, mockLogWarn, mockLogDebug } =
+  vi.hoisted(() => ({
+    mockOutputEnhancerActivate: vi.fn(),
+    mockOutputEnhancerDispose: vi.fn(),
+    mockLogWarn: vi.fn(),
+    mockLogDebug: vi.fn(),
+  }));
+
 vi.mock('./addons/output-enhancer', () => ({
   OutputEnhancerAddon: vi.fn(() => ({
+    activate: mockOutputEnhancerActivate,
     isEnabled: vi.fn(() => true),
     setEnabled: vi.fn(),
     expandLastFold: vi.fn(() => true),
-    dispose: vi.fn(),
+    dispose: mockOutputEnhancerDispose,
   })),
+}));
+
+vi.mock('@/utils/log', () => ({
+  log: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: mockLogWarn,
+    debug: mockLogDebug,
+  },
 }));
 
 // Mock vue-i18n
@@ -292,8 +310,28 @@ describe('Terminal.vue', () => {
 
       await nextTick();
 
-      // loadAddon should be called multiple times for different addons
+      // loadAddon should be called multiple times for xterm-managed addons.
       expect(mockTerminalLoadAddon).toHaveBeenCalled();
+      expect(mockOutputEnhancerActivate).toHaveBeenCalledWith(mockTerminalInstance);
+      expect(
+        mockTerminalLoadAddon.mock.calls.some(
+          ([addon]) => addon?.activate === mockOutputEnhancerActivate,
+        ),
+      ).toBe(false);
+    });
+
+    it('应先 open 终端 DOM 再加载插件', async () => {
+      mount(Terminal, {
+        props: { sessionId: 'session-1' },
+      });
+
+      await nextTick();
+
+      expect(mockTerminalOpen).toHaveBeenCalled();
+      expect(mockTerminalLoadAddon).toHaveBeenCalled();
+      expect(mockTerminalOpen.mock.invocationCallOrder[0]).toBeLessThan(
+        mockTerminalLoadAddon.mock.invocationCallOrder[0],
+      );
     });
 
     it('应调用 open 方法挂载终端', async () => {
@@ -410,7 +448,7 @@ describe('Terminal.vue', () => {
   });
 
   describe('卸载清理', () => {
-    it('卸载时应销毁终端实例', async () => {
+    it('卸载时应销毁终端实例并释放手动管理的输出增强插件', async () => {
       const wrapper = mount(Terminal, {
         props: { sessionId: 'session-1' },
       });
@@ -418,7 +456,30 @@ describe('Terminal.vue', () => {
       await nextTick();
       wrapper.unmount();
 
+      expect(mockOutputEnhancerDispose).toHaveBeenCalled();
       expect(mockTerminalDispose).toHaveBeenCalled();
+    });
+
+    it('xterm dispose 抛 addon 清理错误时不应中断卸载或打印 warn', async () => {
+      mockTerminalDispose.mockImplementationOnce(() => {
+        throw new Error('Could not dispose an addon that has not been loaded');
+      });
+
+      const wrapper = mount(Terminal, {
+        props: { sessionId: 'session-1' },
+      });
+
+      await nextTick();
+
+      expect(() => wrapper.unmount()).not.toThrow();
+      expect(mockTerminalDispose).toHaveBeenCalled();
+      expect(mockLogWarn).not.toHaveBeenCalledWith(
+        expect.stringContaining('xterm dispose 失败'),
+        expect.anything(),
+      );
+      expect(mockLogDebug).toHaveBeenCalledWith(
+        expect.stringContaining('忽略 xterm addon 重复清理错误'),
+      );
     });
   });
 

--- a/packages/frontend/src/features/terminal/Terminal.vue
+++ b/packages/frontend/src/features/terminal/Terminal.vue
@@ -382,6 +382,13 @@ onMounted(() => {
 
     terminalInstance.value = term;
 
+    // 先挂载终端 DOM，再加载依赖渲染尺寸的 addon。
+    // xterm 的 Fit/WebGL/Unicode 等 addon 可能读取 renderService.dimensions，
+    // 在 open() 前加载会导致连接时出现 dimensions undefined。
+    term.open(terminalRef.value);
+    isTerminalDomReady.value = true;
+    log.info(`[Terminal ${props.sessionId}] Xterm open() called.`);
+
     // Load Addons
     term.loadAddon(fitAddon);
     term.loadAddon(new WebLinksAddon());
@@ -398,7 +405,9 @@ onMounted(() => {
         enableLinkDetection: true,
         foldThreshold: 500,
       });
-      term.loadAddon(outputEnhancerAddon);
+      // OutputEnhancerAddon 只 monkey-patch terminal.write，不依赖 xterm AddonManager。
+      // 手动 activate/dispose 可避免 xterm 在整体 dispose 时遇到 addon 管理状态错乱。
+      outputEnhancerAddon.activate(term);
       log.info(
         `[Terminal ${props.sessionId}] OutputEnhancerAddon 加载成功 (enabled: ${terminalOutputEnhancerEnabledBoolean.value})`,
       );
@@ -413,13 +422,10 @@ onMounted(() => {
     // 使用 composable 初始化渲染器（自动选择 WebGL/Canvas/DOM）
     initRenderer();
 
-    term.open(terminalRef.value);
-    isTerminalDomReady.value = true;
     // 仅在用户启用 FPS 显示时启动采样，避免无用 RAF 循环
     if (isFpsEnabled.value) {
       startMonitoring();
     }
-    log.info(`[Terminal ${props.sessionId}] Xterm open() called.`);
 
     applyTerminalWrapMode();
 
@@ -623,8 +629,7 @@ onBeforeUnmount(() => {
     textareaKeydownHandler.value = null;
   }
 
-  // OutputEnhancerAddon 会替换 terminal.write，需在 terminal 仍存活时先恢复原始方法。
-  // terminal.dispose() 也会清理已加载 addon，但此处提前 dispose 可避免 monkey-patch 残留。
+  // OutputEnhancerAddon 未交给 xterm AddonManager，需在 terminal.dispose() 前手动恢复 write。
   if (outputEnhancerAddon) {
     try {
       outputEnhancerAddon.dispose();
@@ -635,13 +640,34 @@ onBeforeUnmount(() => {
     }
   }
 
-  if (terminalInstance.value) {
-    terminalInstance.value.dispose();
-    terminalInstance.value = null;
+  if (selectionListenerDisposable) {
+    try {
+      selectionListenerDisposable.dispose();
+    } catch (error: unknown) {
+      log.warn(`[Terminal ${props.sessionId}] Selection listener dispose 失败:`, error);
+    } finally {
+      selectionListenerDisposable = null;
+    }
   }
 
-  if (selectionListenerDisposable) {
-    selectionListenerDisposable.dispose();
+  if (terminalInstance.value) {
+    try {
+      terminalInstance.value.dispose();
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      if (errorMessage.includes('Could not dispose an addon that has not been loaded')) {
+        log.debug(`[Terminal ${props.sessionId}] 忽略 xterm addon 重复清理错误: ${errorMessage}`);
+      } else {
+        log.warn(
+          `[Terminal ${props.sessionId}] xterm dispose 失败，已忽略以避免关闭会话中断:`,
+          error,
+        );
+      }
+    } finally {
+      terminalInstance.value = null;
+      outputEnhancerAddon = null;
+      searchAddon = null;
+    }
   }
 
   removeContextMenuListener();


### PR DESCRIPTION
## Summary by Sourcery

Adjust terminal lifecycle, SFTP uploads, and WebRTC bridge/signaling behavior for better robustness and correctness across frontend and backend.

Bug Fixes:
- Ensure xterm DOM is opened before loading addons and manually manage OutputEnhancer lifecycle to avoid addon manager state corruption and dispose-time errors.
- Prevent WebRTC bridge from using invalid or mismatched remote gateway URLs and align werift ICE server configuration with standard ICE config.
- Fix SFTP upload progress and chunk acknowledgement payloads to always include uploadId, and handle stream backpressure and write callbacks more reliably.
- Correct SFTP frontend archive naming to preserve leading-dot filenames when compressing single files and to handle empty base paths safely.
- Avoid double-disposing WebGL terminal addons by separating renderer cleanup from terminal disposal and hardening terminal teardown against selection listener and xterm dispose errors.
- Increase WebSocket rate limits for SFTP upload start/chunk messages to better support multi-file and windowed uploads without false positives.

Enhancements:
- Expose a shared default WebRTC connect timeout aligned with backend bridge connection windows and use it in the WebRTCTunnel config.
- Add and extend unit tests for terminal behavior, SFTP upload messaging, WebRTC ICE config, upload chunk manager progress updates, WebRTC tunnel factory, and WebSocket rate limiter behavior.

Tests:
- Expand frontend and backend unit coverage around terminal addon lifecycle, SFTP uploads, WebRTC signaling/bridge behavior, upload chunk progress updates, WebRTC tunnel utilities, and WebSocket rate limits.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes critical issues in SFTP uploads, WebRTC tunnel setup, and terminal addon lifecycle. Improves reliability for bulk uploads and remote desktop connections, and prevents xterm init/cleanup crashes.

- **Bug Fixes**
  - SFTP upload
    - Include uploadId in `sftp:upload:progress` and `sftp:upload:chunk:ack`.
    - Fix backpressure hangs: resolve only after write callback and drain; handle drain-before-callback safely.
    - Correct memory accounting for duplicate chunks by replacing pending buffers (no double-counting).
    - Exempt `sftp:upload:chunk` from WS rate limiting; allow `sftp:upload:start` up to 100/s.
  - Upload UI
    - Update optimistic progress immediately after sending a chunk.
    - Add upload-start queue (max 8 concurrent starts) with auto backfill on complete/cancel/error.
  - Compression
    - Preserve dotfile basenames: `.env` compresses to `.env.zip` (not `.zip`).
  - WebRTC
    - Bridge rebuilds remote-gateway URL from server base (keeps query), validates input, and keeps SSRF pinning.
    - Expand multi-URL ICE into single entries for werift and use them in RTCPeerConnection.
    - Default connect timeout set to 16s to avoid premature fallback during slow handshakes.
  - Terminal
    - Call `term.open()` before loading addons to avoid undefined dimensions.
    - Manually activate/dispose OutputEnhancer (no xterm AddonManager), avoid double-dispose of `@xterm/addon-webgl`, and ignore known duplicate-cleanup errors on unmount.

<sup>Written for commit c0995148a7a27bf629272b52738a5d0c5c12539d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Silentely/nexus-terminal/pull/106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

