### PR TITLE
修复 WebRTC 桥接和上传异常处理

### DIFF
--- a/docs/configuration/docker.md
+++ b/docs/configuration/docker.md
@@ -59,6 +59,8 @@
 | `REMOTE_GATEWAY_WS_URL_LOCAL`    | `ws://localhost:8081`        | 本地开发时远程网关 WebSocket 地址    |
 | `REMOTE_GATEWAY_WS_URL_DOCKER`   | `ws://remote-gateway:8081`   | Docker 部署时远程网关 WebSocket 地址 |
 
+`REMOTE_GATEWAY_WS_URL_*` 可包含反向代理路径；WebRTC 远程桌面桥接会保留该路径并追加连接参数。
+
 ### Remote Gateway API 鉴权（推荐）
 
 > ✅ 建议为远程网关 API 配置共享令牌，避免 token 生成接口在端口被误暴露时可被滥用。
@@ -490,7 +492,7 @@ services:
 
 - **外观模块** — HTML 主题远程加载
 - **AI 智能运维** — NL2CMD 的 URL 抓取功能
-- **WebRTC 远程桌面桥接** — 验证 `remoteGatewayUrl` 不指向私有/内部地址，阻止恶意网关 URL 建立 WebSocket 连接
+- **WebRTC 远程桌面桥接** — 使用服务端配置的 remote-gateway WebSocket 地址建立连接，并在外部地址场景下进行 SSRF 校验与 DNS 绑定
 - **SSRF DNS 缓存** — 使用 `ipaddr.js` 检测 IP 地址格式，避免直接 IP 被误缓存为域名
 
 无需配置，自动生效。

--- a/packages/backend/src/sftp/sftp-file-content-operations.test.ts
+++ b/packages/backend/src/sftp/sftp-file-content-operations.test.ts
@@ -1,4 +1,3 @@
-import WebSocket from 'ws';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { EventEmitter } from 'events';
 import * as iconv from 'iconv-lite';
@@ -44,7 +43,7 @@ class MockWriteStream extends EventEmitter {
 
 const createState = (): MockState => {
   return {
-    ws: { send: vi.fn(), readyState: 1, readyState: 1 },
+    ws: { send: vi.fn(), readyState: 1 },
     sftp: {
       createReadStream: vi.fn(),
       createWriteStream: vi.fn(),
@@ -84,7 +83,7 @@ describe('sftp-file-content-operations', () => {
 
   describe('executeReadFileContentOperation', () => {
     it('SFTP 未就绪时返回错误消息', async () => {
-      const state = { ws: { send: vi.fn(), readyState: 1, readyState: 1 } } as unknown as MockState;
+      const state = { ws: { send: vi.fn(), readyState: 1 } } as unknown as MockState;
       await executeReadFileContentOperation(state, sessionId, '/tmp/a.txt', requestId);
 
       const payload = parseLastPayload(state.ws.send);
@@ -144,7 +143,7 @@ describe('sftp-file-content-operations', () => {
 
   describe('executeWriteFileContentOperation', () => {
     it('SFTP 未就绪时返回错误消息', async () => {
-      const state = { ws: { send: vi.fn(), readyState: 1, readyState: 1 } } as unknown as MockState;
+      const state = { ws: { send: vi.fn(), readyState: 1 } } as unknown as MockState;
       await executeWriteFileContentOperation(state, sessionId, '/tmp/a.txt', 'x', requestId);
 
       const payload = parseLastPayload(state.ws.send);

--- a/packages/backend/src/sftp/sftp-path-operations.test.ts
+++ b/packages/backend/src/sftp/sftp-path-operations.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { EventEmitter } from 'events';
-import WebSocket from 'ws';
 import type { ClientState } from '../websocket/types';
 import {
   executeMkdirPathOperation,

--- a/packages/backend/src/sftp/sftp-path-query-operations.test.ts
+++ b/packages/backend/src/sftp/sftp-path-query-operations.test.ts
@@ -1,4 +1,3 @@
-import WebSocket from 'ws';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import type { ClientState } from '../websocket/types';
 import {
@@ -35,7 +34,7 @@ const createMockStats = (kind: 'file' | 'directory' = 'file') => ({
 
 const createState = (): MockState => {
   return {
-    ws: { send: vi.fn(), readyState: 1, readyState: 1 },
+    ws: { send: vi.fn(), readyState: 1 },
     sftp: {
       lstat: vi.fn(),
       chmod: vi.fn(),
@@ -60,7 +59,7 @@ describe('sftp-path-query-operations', () => {
 
   describe('executeStatPathQueryOperation', () => {
     it('SFTP 未就绪时返回错误', async () => {
-      const state = { ws: { send: vi.fn(), readyState: 1, readyState: 1 } } as unknown as MockState;
+      const state = { ws: { send: vi.fn(), readyState: 1 } } as unknown as MockState;
       await executeStatPathQueryOperation(state, sessionId, '/tmp/a.txt', requestId);
       const payload = parseLastPayload(state.ws.send);
       expect(payload.type).toBe('sftp:stat:error');
@@ -99,7 +98,7 @@ describe('sftp-path-query-operations', () => {
 
   describe('executeChmodPathQueryOperation', () => {
     it('SFTP 未就绪时返回错误', async () => {
-      const state = { ws: { send: vi.fn(), readyState: 1, readyState: 1 } } as unknown as MockState;
+      const state = { ws: { send: vi.fn(), readyState: 1 } } as unknown as MockState;
       await executeChmodPathQueryOperation(state, sessionId, '/tmp/a.txt', 0o644, requestId);
       const payload = parseLastPayload(state.ws.send);
       expect(payload.type).toBe('sftp:chmod:error');
@@ -157,7 +156,7 @@ describe('sftp-path-query-operations', () => {
 
   describe('executeRealpathPathQueryOperation', () => {
     it('SFTP 未就绪时返回错误', async () => {
-      const state = { ws: { send: vi.fn(), readyState: 1, readyState: 1 } } as unknown as MockState;
+      const state = { ws: { send: vi.fn(), readyState: 1 } } as unknown as MockState;
       await executeRealpathPathQueryOperation(
         state,
         sessionId,

--- a/packages/backend/src/sftp/sftp.service.test.ts
+++ b/packages/backend/src/sftp/sftp.service.test.ts
@@ -1125,6 +1125,11 @@ describe('SftpService', () => {
         Buffer.from('hello').toString('base64'),
       );
 
+      expect(mockWriteStream.write).toHaveBeenCalledWith(
+        Buffer.from('hello'),
+        expect.any(Function),
+      );
+
       const sentMessages = mockWs.send.mock.calls.map(([raw]) => JSON.parse(raw as string));
       expect(sentMessages).toContainEqual(
         expect.objectContaining({

--- a/packages/backend/src/webrtc/bridge.test.ts
+++ b/packages/backend/src/webrtc/bridge.test.ts
@@ -1,0 +1,173 @@
+import { EventEmitter } from 'events';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import WebSocket from 'ws';
+import { bridgeDataChannelToGateway } from './bridge';
+import { resolveAndValidatePublicHost } from '../utils/url';
+import { logger } from '../utils/logger';
+
+type MockGatewayWebSocket = EventEmitter & {
+  send: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+};
+
+type MockDataChannel = {
+  send: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+  onMessage: { subscribe: ReturnType<typeof vi.fn> };
+  onclose?: () => void;
+};
+
+let capturedGatewayWs: MockGatewayWebSocket | null = null;
+
+vi.mock('ws', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('ws')>();
+  const MockWebSocket = vi.fn().mockImplementation(() => {
+    const ws = new EventEmitter() as MockGatewayWebSocket;
+    ws.send = vi.fn();
+    ws.close = vi.fn();
+    capturedGatewayWs = ws;
+    return ws;
+  }) as any;
+
+  MockWebSocket.OPEN = 1;
+  return { ...actual, default: MockWebSocket };
+});
+
+vi.mock('../utils/url', () => ({
+  resolveAndValidatePublicHost: vi.fn(),
+}));
+
+vi.mock('../utils/ssrf-guard', () => ({
+  createPinnedLookup: vi.fn().mockReturnValue(vi.fn()),
+}));
+
+vi.mock('../utils/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+function createDataChannel(): MockDataChannel {
+  return {
+    send: vi.fn(),
+    close: vi.fn(),
+    onMessage: { subscribe: vi.fn() },
+  };
+}
+
+describe('bridgeDataChannelToGateway', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedGatewayWs = null;
+    process.env = { ...originalEnv, DEPLOYMENT_MODE: 'local' };
+    vi.mocked(resolveAndValidatePublicHost).mockResolvedValue({
+      hostname: 'gateway.example.com',
+      addresses: ['203.0.113.10'],
+    });
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('validates external WebSocket gateway URLs through an HTTP-equivalent URL and keeps the configured path', async () => {
+    process.env.REMOTE_GATEWAY_WS_URL_LOCAL = 'wss://gateway.example.com/remote/bridge';
+    const dc = createDataChannel();
+
+    await bridgeDataChannelToGateway(
+      dc as unknown as Parameters<typeof bridgeDataChannelToGateway>[0],
+      'wss://client-controlled.example.net/ignored?token=secret-token#fragment',
+      'session-1',
+    );
+
+    expect(resolveAndValidatePublicHost).toHaveBeenCalledWith(
+      'https://gateway.example.com/remote/bridge?token=secret-token',
+      'WebRTC-Bridge-session-1',
+    );
+    expect(WebSocket).toHaveBeenCalledWith(
+      'wss://gateway.example.com/remote/bridge?token=secret-token',
+      expect.objectContaining({ agent: expect.any(Object) }),
+    );
+    expect(capturedGatewayWs).not.toBeNull();
+  });
+
+  it('validates external ws gateway URLs through an http URL', async () => {
+    process.env.REMOTE_GATEWAY_WS_URL_LOCAL = 'ws://gateway.example.com/plain-ws';
+    const dc = createDataChannel();
+
+    await bridgeDataChannelToGateway(
+      dc as unknown as Parameters<typeof bridgeDataChannelToGateway>[0],
+      'ws://client.example.net/ignored?token=secret-token',
+      'session-ws',
+    );
+
+    expect(resolveAndValidatePublicHost).toHaveBeenCalledWith(
+      'http://gateway.example.com/plain-ws?token=secret-token',
+      'WebRTC-Bridge-session-ws',
+    );
+    expect(WebSocket).toHaveBeenCalledWith(
+      'ws://gateway.example.com/plain-ws?token=secret-token',
+      expect.objectContaining({ agent: expect.any(Object) }),
+    );
+  });
+
+  it('does not log raw configured gateway URLs that may contain sensitive query values', async () => {
+    process.env.REMOTE_GATEWAY_WS_URL_LOCAL = 'not a url?token=secret-token';
+    const dc = createDataChannel();
+
+    await bridgeDataChannelToGateway(
+      dc as unknown as Parameters<typeof bridgeDataChannelToGateway>[0],
+      'wss://client.example.net/ignored',
+      'session-config',
+    );
+
+    const serializedLogs = JSON.stringify(vi.mocked(logger.error).mock.calls);
+    const serializedClientMessages = JSON.stringify(dc.send.mock.calls);
+
+    expect(serializedLogs).not.toContain('secret-token');
+    expect(serializedClientMessages).not.toContain('secret-token');
+  });
+
+  it('does not log raw invalid gateway URLs that may contain sensitive query values', async () => {
+    const dc = createDataChannel();
+
+    await bridgeDataChannelToGateway(
+      dc as unknown as Parameters<typeof bridgeDataChannelToGateway>[0],
+      'not a url?token=secret-token',
+      'session-2',
+    );
+
+    const serializedLogs = JSON.stringify(vi.mocked(logger.error).mock.calls);
+    const serializedClientMessages = JSON.stringify(dc.send.mock.calls);
+
+    expect(serializedLogs).not.toContain('secret-token');
+    expect(serializedClientMessages).not.toContain('secret-token');
+  });
+
+  it('does not expose raw SSRF validation errors that may contain gateway query values', async () => {
+    process.env.REMOTE_GATEWAY_WS_URL_LOCAL = 'wss://gateway.example.com/remote';
+    vi.mocked(resolveAndValidatePublicHost).mockRejectedValueOnce(
+      Object.assign(new Error('blocked token=secret-token'), {
+        input: 'https://gateway.example.com/remote?token=secret-token',
+      }),
+    );
+    const dc = createDataChannel();
+
+    await bridgeDataChannelToGateway(
+      dc as unknown as Parameters<typeof bridgeDataChannelToGateway>[0],
+      'wss://client.example.net/ignored?token=secret-token',
+      'session-3',
+    );
+
+    const serializedLogs = JSON.stringify(vi.mocked(logger.error).mock.calls);
+    const serializedClientMessages = JSON.stringify(dc.send.mock.calls);
+
+    expect(serializedLogs).not.toContain('secret-token');
+    expect(serializedClientMessages).not.toContain('secret-token');
+  });
+});

--- a/packages/backend/src/webrtc/bridge.ts
+++ b/packages/backend/src/webrtc/bridge.ts
@@ -48,15 +48,39 @@ function getRemoteGatewayWsBaseUrl(): string {
   return 'ws://localhost:8081';
 }
 
+function getSafeErrorDetails(error: unknown): { name: string; code?: string } {
+  if (error instanceof Error) {
+    const code = (error as Error & { code?: unknown }).code;
+    return {
+      name: error.name || 'Error',
+      ...(typeof code === 'string' ? { code } : {}),
+    };
+  }
+
+  return { name: typeof error };
+}
+
 function resolveRemoteGatewayUrl(remoteGatewayUrl: string): string {
   const incomingUrl = new URL(remoteGatewayUrl);
   const gatewayBaseUrl = new URL(getRemoteGatewayWsBaseUrl());
 
   gatewayBaseUrl.search = incomingUrl.search;
   gatewayBaseUrl.hash = '';
-  gatewayBaseUrl.pathname = '/';
 
   return gatewayBaseUrl.toString();
+}
+
+function toHttpValidationUrl(gatewayUrl: string): string {
+  const validationUrl = new URL(gatewayUrl);
+  if (validationUrl.protocol === 'ws:') {
+    validationUrl.protocol = 'http:';
+  } else if (validationUrl.protocol === 'wss:') {
+    validationUrl.protocol = 'https:';
+  } else {
+    throw new Error('remote-gateway WebSocket URL 必须使用 ws/wss 协议');
+  }
+  validationUrl.hash = '';
+  return validationUrl.toString();
 }
 
 /**
@@ -82,11 +106,13 @@ export async function bridgeDataChannelToGateway(
   try {
     gatewayUrl = resolveRemoteGatewayUrl(remoteGatewayUrl);
   } catch (error) {
-    logger.error(`[WebRTC Bridge] remoteGatewayUrl 无效: ${sessionId}`, error);
+    logger.error(`[WebRTC Bridge] remoteGatewayUrl 无效: ${sessionId}`, {
+      error: getSafeErrorDetails(error),
+    });
     dc.send(
       JSON.stringify({
         type: 'error',
-        payload: `remote-gateway URL 无效: ${error instanceof Error ? error.message : '未知错误'}`,
+        payload: 'remote-gateway URL 无效，请检查服务端网关配置',
       }),
     );
     return;
@@ -96,19 +122,22 @@ export async function bridgeDataChannelToGateway(
   let agent: http.Agent | undefined;
   if (!isInternalGatewayUrl(gatewayUrl)) {
     try {
+      const validationUrl = toHttpValidationUrl(gatewayUrl);
       const { addresses } = await resolveAndValidatePublicHost(
-        gatewayUrl,
+        validationUrl,
         `WebRTC-Bridge-${sessionId}`,
       );
       const lookup = createPinnedLookup(addresses);
       const urlObj = new URL(gatewayUrl);
       agent = urlObj.protocol === 'wss:' ? new https.Agent({ lookup }) : new http.Agent({ lookup });
     } catch (error) {
-      logger.error(`[WebRTC Bridge] SSRF 验证失败: ${sessionId}`, error);
+      logger.error(`[WebRTC Bridge] SSRF 验证失败: ${sessionId}`, {
+        error: getSafeErrorDetails(error),
+      });
       dc.send(
         JSON.stringify({
           type: 'error',
-          payload: `remote-gateway URL 验证失败: ${error instanceof Error ? error.message : '未知错误'}`,
+          payload: 'remote-gateway URL 验证失败，请检查服务端网关配置',
         }),
       );
       return;

--- a/packages/frontend/src/composables/uploadProgress.ts
+++ b/packages/frontend/src/composables/uploadProgress.ts
@@ -1,0 +1,5 @@
+export const calculateUploadProgress = (completedBytes: number, totalBytes: number): number => {
+  if (totalBytes <= 0) return 100;
+  if (completedBytes >= totalBytes) return 100;
+  return Math.min(99, Math.max(0, Math.floor((completedBytes / totalBytes) * 100)));
+};

--- a/packages/frontend/src/composables/useFileUploader.test.ts
+++ b/packages/frontend/src/composables/useFileUploader.test.ts
@@ -210,6 +210,31 @@ describe('useFileUploader', () => {
 
       expect(wsDeps.value.sendMessage).toHaveBeenCalledTimes(9);
     });
+
+    it('上传开始消息发送失败时不应永久占用启动槽位', () => {
+      const sessionId = ref('s1');
+      const currentPath = ref('/home');
+      const fileList = ref([]) as any;
+      const sendMessage = vi.fn().mockReturnValueOnce(false).mockReturnValue(true);
+      const wsDeps = makeWsDeps({ sendMessage });
+
+      const { uploads, startFileUpload } = useFileUploader(
+        sessionId,
+        currentPath,
+        fileList,
+        wsDeps,
+      );
+
+      for (let i = 0; i < 9; i++) {
+        startFileUpload(makeFile(`file-${i}.txt`));
+      }
+
+      expect(sendMessage).toHaveBeenCalledTimes(9);
+      const failedUpload = Object.values(uploads).find(
+        (upload) => upload.filename === 'file-0.txt',
+      );
+      expect(failedUpload?.status).toBe('error');
+    });
   });
 
   describe('cancelUpload', () => {
@@ -576,6 +601,38 @@ describe('useFileUploader', () => {
 
       // 应取较大值 80%
       expect(uploads[uploadId].progress).toBe(80);
+    });
+
+    it('onUploadProgress 不应在后端成功前把乐观进度四舍五入到 100', () => {
+      const sessionId = ref('s1');
+      const currentPath = ref('/home');
+      const fileList = ref([]) as any;
+      const wsDeps = makeWsDeps();
+
+      const messageHandlers: Record<string, Function> = {};
+      wsDeps.value.onMessage = vi.fn().mockImplementation((type: string, handler: Function) => {
+        messageHandlers[type] = handler;
+        return vi.fn();
+      });
+
+      const { uploads, startFileUpload } = useFileUploader(
+        sessionId,
+        currentPath,
+        fileList,
+        wsDeps,
+      );
+
+      startFileUpload(makeFile('almost.bin', 10000));
+      const uploadId = Object.keys(uploads)[0];
+      uploads[uploadId].status = 'uploading';
+      uploads[uploadId].sentBytes = 9950;
+
+      messageHandlers['sftp:upload:progress'](
+        { bytesWritten: 5000, totalSize: 10000 },
+        { uploadId },
+      );
+
+      expect(uploads[uploadId].progress).toBe(99);
     });
 
     it('totalSize 为 0 时进度应为 100 而非 NaN', () => {

--- a/packages/frontend/src/composables/useFileUploader.ts
+++ b/packages/frontend/src/composables/useFileUploader.ts
@@ -6,6 +6,7 @@ import type { WebSocketMessage, MessagePayload } from '../types/websocket.types'
 
 import type { WebSocketDependencies } from './useSftpActions';
 import { sendFileChunks, type ChunkManagerDeps } from './useUploadChunkManager';
+import { calculateUploadProgress } from './uploadProgress';
 import { log } from '@/utils/log';
 
 const generateUploadId = (): string => {
@@ -53,22 +54,44 @@ export function useFileUploader(
         ['pending', 'uploading', 'paused'].includes(upload.status),
     ).length;
 
-  const sendUploadStart = (uploadId: string, upload: QueuedUploadItem): void => {
+  const markUploadStartFailed = (uploadId: string, error?: unknown): void => {
+    const failedUpload = uploads[uploadId] as QueuedUploadItem | undefined;
+    if (!failedUpload) return;
+    failedUpload.startRequested = false;
+    failedUpload.status = 'error';
+    failedUpload.error = t('fileManager.errors.uploadFailed');
+    log.error(
+      `[FileUploader ${sessionIdForLog.value}] Failed to send upload start for ${uploadId}:`,
+      error,
+    );
+  };
+
+  const sendUploadStart = (uploadId: string, upload: QueuedUploadItem): boolean => {
     const queuedUpload = uploads[uploadId] as QueuedUploadItem | undefined;
-    if (!queuedUpload) return;
+    if (!queuedUpload) return false;
     queuedUpload.startRequested = true;
     log.info(
       `[FileUploader ${sessionIdForLog.value}] Starting upload ${uploadId} to ${upload.remotePath}`,
     );
-    wsDeps.value.sendMessage({
-      type: 'sftp:upload:start',
-      payload: {
-        uploadId,
-        remotePath: upload.remotePath,
-        size: upload.file.size,
-        relativePath: upload.relativePath,
-      },
-    });
+    try {
+      const sendResult = wsDeps.value.sendMessage({
+        type: 'sftp:upload:start',
+        payload: {
+          uploadId,
+          remotePath: upload.remotePath,
+          size: upload.file.size,
+          relativePath: upload.relativePath,
+        },
+      });
+      if (sendResult === false || !wsDeps.value.isConnected.value) {
+        markUploadStartFailed(uploadId);
+        return false;
+      }
+    } catch (error: unknown) {
+      markUploadStartFailed(uploadId, error);
+      return false;
+    }
+    return true;
   };
 
   const pumpUploadStartQueue = (): void => {
@@ -80,8 +103,9 @@ export function useFileUploader(
     for (const [uploadId, upload] of Object.entries(uploads) as Array<[string, QueuedUploadItem]>) {
       if (availableSlots <= 0) break;
       if (upload.status === 'pending' && !upload.startRequested) {
-        sendUploadStart(uploadId, upload);
-        availableSlots--;
+        if (sendUploadStart(uploadId, upload)) {
+          availableSlots--;
+        }
       }
     }
   };
@@ -351,15 +375,12 @@ export function useFileUploader(
       // payload 现在应该包含 bytesWritten 和 totalSize
       if (typeof payloadObj.bytesWritten === 'number' && typeof payloadObj.totalSize === 'number') {
         // 后端确认进度（totalSize 为 0 时直接视为完成，避免 NaN）
-        const backendProgress =
-          payloadObj.totalSize > 0
-            ? Math.min(100, Math.round((payloadObj.bytesWritten / payloadObj.totalSize) * 100))
-            : 100;
+        const backendProgress = calculateUploadProgress(
+          payloadObj.bytesWritten,
+          payloadObj.totalSize,
+        );
         // 乐观进度（基于前端已发送字节数）
-        const optimisticProgress =
-          upload.file.size > 0
-            ? Math.min(100, Math.round((upload.sentBytes / upload.file.size) * 100))
-            : 100;
+        const optimisticProgress = calculateUploadProgress(upload.sentBytes, upload.file.size);
         // 取较大值：乐观进度提供即时反馈，后端确认进度保证准确性
         upload.progress = Math.max(backendProgress, optimisticProgress);
       } else {

--- a/packages/frontend/src/composables/useSftpActions.ts
+++ b/packages/frontend/src/composables/useSftpActions.ts
@@ -14,7 +14,7 @@ import { log } from '@/utils/log';
  * @description Defines the necessary functions and state required from a WebSocket manager instance.
  */
 export interface WebSocketDependencies {
-  sendMessage: (message: WebSocketMessage) => void;
+  sendMessage: (message: WebSocketMessage) => boolean | void;
   onMessage: (type: string, handler: MessageHandler) => () => void;
   isConnected: ComputedRef<boolean>;
   isSftpReady: Readonly<Ref<boolean>>;

--- a/packages/frontend/src/composables/useUploadChunkManager.test.ts
+++ b/packages/frontend/src/composables/useUploadChunkManager.test.ts
@@ -19,6 +19,24 @@ class MockFileReader {
   }
 }
 
+class ControlledFileReader {
+  static readers: ControlledFileReader[] = [];
+  onload: ((event: { target: { result: string } }) => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  readAsDataURL(): void {
+    ControlledFileReader.readers.push(this);
+  }
+
+  emitLoad(): void {
+    this.onload?.({
+      target: {
+        result: 'data:application/octet-stream;base64,eA==',
+      },
+    });
+  }
+}
+
 describe('sendFileChunks', () => {
   const OriginalFileReader = globalThis.FileReader;
 
@@ -66,5 +84,124 @@ describe('sendFileChunks', () => {
     );
     expect(uploads['upload-1'].sentBytes).toBeGreaterThan(0);
     expect(uploads['upload-1'].progress).toBeGreaterThan(0);
+  });
+
+  it('最后一块发送前乐观进度不应提前显示为 100', () => {
+    globalThis.FileReader = ControlledFileReader as unknown as typeof FileReader;
+    ControlledFileReader.readers = [];
+    const firstChunkSize = 1024 * 256;
+    const fileSize = Math.ceil(firstChunkSize / 0.995);
+    const file = new File([new Uint8Array(fileSize)], 'almost.bin');
+    const uploads: Record<string, UploadItem> = {
+      'upload-1': {
+        id: 'upload-1',
+        file,
+        filename: 'almost.bin',
+        progress: 0,
+        sentBytes: 0,
+        status: 'uploading',
+      },
+    };
+    const sendMessage = vi.fn();
+    const deps: ChunkManagerDeps = {
+      uploads,
+      sessionIdForLog: ref('session-1'),
+      t: (key: string) => key,
+      wsDeps: ref({
+        isConnected: { value: true },
+        isSftpReady: { value: true },
+        sendMessage,
+        onMessage: vi.fn().mockReturnValue(vi.fn()),
+      } as any),
+    };
+
+    sendFileChunks(deps, 'upload-1', file);
+    expect(ControlledFileReader.readers).toHaveLength(2);
+
+    ControlledFileReader.readers[0].emitLoad();
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(uploads['upload-1'].sentBytes).toBe(firstChunkSize);
+    expect(uploads['upload-1'].progress).toBe(99);
+  });
+
+  it('分块消息发送失败时不应推进乐观进度', () => {
+    globalThis.FileReader = ControlledFileReader as unknown as typeof FileReader;
+    ControlledFileReader.readers = [];
+    const file = new File([new Uint8Array(1024)], 'failed.bin');
+    const uploads: Record<string, UploadItem> = {
+      'upload-1': {
+        id: 'upload-1',
+        file,
+        filename: 'failed.bin',
+        progress: 0,
+        sentBytes: 0,
+        status: 'uploading',
+      },
+    };
+    const sendMessage = vi.fn().mockReturnValue(false);
+    const unregisterAck = vi.fn();
+    const deps: ChunkManagerDeps = {
+      uploads,
+      sessionIdForLog: ref('session-1'),
+      t: (key: string) => key,
+      wsDeps: ref({
+        isConnected: { value: true },
+        isSftpReady: { value: true },
+        sendMessage,
+        onMessage: vi.fn().mockReturnValue(unregisterAck),
+      } as any),
+    };
+
+    sendFileChunks(deps, 'upload-1', file);
+    expect(ControlledFileReader.readers).toHaveLength(1);
+
+    ControlledFileReader.readers[0].emitLoad();
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(uploads['upload-1'].status).toBe('error');
+    expect(uploads['upload-1'].error).toBe('fileManager.errors.uploadFailed');
+    expect(uploads['upload-1'].sentBytes).toBe(0);
+    expect(uploads['upload-1'].progress).toBe(0);
+    expect(unregisterAck).toHaveBeenCalled();
+    expect(
+      (uploads['upload-1'] as UploadItem & { _unregisterAck?: () => void })._unregisterAck,
+    ).toBeUndefined();
+  });
+
+  it('零字节文件分块消息发送失败时应标记上传失败', () => {
+    const file = new File([], 'empty.bin');
+    const uploads: Record<string, UploadItem> = {
+      'upload-1': {
+        id: 'upload-1',
+        file,
+        filename: 'empty.bin',
+        progress: 0,
+        sentBytes: 0,
+        status: 'uploading',
+      },
+    };
+    const sendMessage = vi.fn().mockReturnValue(false);
+    const unregisterAck = vi.fn();
+    const deps: ChunkManagerDeps = {
+      uploads,
+      sessionIdForLog: ref('session-1'),
+      t: (key: string) => key,
+      wsDeps: ref({
+        isConnected: { value: true },
+        isSftpReady: { value: true },
+        sendMessage,
+        onMessage: vi.fn().mockReturnValue(unregisterAck),
+      } as any),
+    };
+
+    sendFileChunks(deps, 'upload-1', file);
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'sftp:upload:chunk' }),
+    );
+    expect(uploads['upload-1'].status).toBe('error');
+    expect(uploads['upload-1'].progress).toBe(0);
+    expect(unregisterAck).toHaveBeenCalled();
   });
 });

--- a/packages/frontend/src/composables/useUploadChunkManager.ts
+++ b/packages/frontend/src/composables/useUploadChunkManager.ts
@@ -7,6 +7,7 @@ import type { UploadItem } from '../types/upload.types';
 import type { WebSocketMessage, MessagePayload } from '../types/websocket.types';
 import type { TranslateFn } from '../types/i18n.types';
 import type { WebSocketDependencies } from './useSftpActions';
+import { calculateUploadProgress } from './uploadProgress';
 import { log } from '@/utils/log';
 
 /** 分块大小：256KB（优化：减少消息数量，降低内存压力） */
@@ -61,6 +62,25 @@ export function sendFileChunks(
   let inFlight = 0; // 当前在途（已发送未确认）的块数量
   let ackReceived = false; // 标记是否收到过 ack（用于判断后端是否支持滑动窗口）
   let ackFallbackTimer: ReturnType<typeof setTimeout> | null = null;
+  let unregisterAck: (() => void) | undefined;
+
+  const clearAckResources = (): void => {
+    if (ackFallbackTimer) {
+      clearTimeout(ackFallbackTimer);
+      ackFallbackTimer = null;
+    }
+    unregisterAck?.();
+    unregisterAck = undefined;
+    (upload as UploadItem & { _unregisterAck?: () => void })._unregisterAck = undefined;
+  };
+
+  const markUploadFailed = (errorKey: string): void => {
+    const failedUpload = uploads[uploadId];
+    if (!failedUpload) return;
+    failedUpload.status = 'error';
+    failedUpload.error = t(errorKey);
+    clearAckResources();
+  };
 
   // 每个块创建独立的 FileReader，避免 InvalidStateError（FileReader 状态机限制）
   const readAndSendChunk = () => {
@@ -93,26 +113,30 @@ export function sendFileChunks(
         const isLast = currentOffset + CHUNK_SIZE >= file.size;
         const chunkIndex = Math.floor(currentOffset / CHUNK_SIZE);
 
-        wsDeps.value.sendMessage({
+        const sent = wsDeps.value.sendMessage({
           type: 'sftp:upload:chunk',
           payload: { uploadId, chunkIndex, data: chunkBase64, isLast },
         });
+        if (sent === false) {
+          log.error(
+            `[FileUploader ${sessionIdForLog.value}] Failed to send chunk for ${uploadId} at offset ${currentOffset}.`,
+          );
+          markUploadFailed('fileManager.errors.uploadFailed');
+          inFlight = Math.max(0, inFlight - 1);
+          return;
+        }
 
         // 乐观进度：发送后立即更新已发送字节数，提供即时进度反馈
         if (currentUpload) {
           currentUpload.sentBytes = Math.min(currentUpload.sentBytes + currentChunkSize, file.size);
-          currentUpload.progress =
-            file.size > 0
-              ? Math.min(100, Math.round((currentUpload.sentBytes / file.size) * 100))
-              : 100;
+          currentUpload.progress = calculateUploadProgress(currentUpload.sentBytes, file.size);
         }
       } else {
         log.error(
           `[FileUploader ${sessionIdForLog.value}] FileReader returned unexpected result for ${uploadId}:`,
           chunkResult,
         );
-        currentUpload.status = 'error';
-        currentUpload.error = t('fileManager.errors.readFileError');
+        markUploadFailed('fileManager.errors.readFileError');
         inFlight = Math.max(0, inFlight - 1);
       }
     };
@@ -123,8 +147,7 @@ export function sendFileChunks(
       );
       const failedUpload = uploads[uploadId];
       if (failedUpload) {
-        failedUpload.status = 'error';
-        failedUpload.error = t('fileManager.errors.readFileError');
+        markUploadFailed('fileManager.errors.readFileError');
       }
       inFlight = Math.max(0, inFlight - 1);
     };
@@ -179,7 +202,7 @@ export function sendFileChunks(
   };
 
   // 注册 ack 处理器
-  const unregisterAck = wsDeps.value.onMessage('sftp:upload:chunk:ack', onChunkAck);
+  unregisterAck = wsDeps.value.onMessage('sftp:upload:chunk:ack', onChunkAck);
 
   // 保存注销函数到 upload 对象，以便取消时清理
   (upload as UploadItem & { _unregisterAck?: () => void })._unregisterAck = unregisterAck;
@@ -194,10 +217,14 @@ export function sendFileChunks(
   } else {
     // 零字节文件直接发送
     log.info(`[FileUploader ${sessionIdForLog.value}] Processing zero-byte file ${uploadId}`);
-    wsDeps.value.sendMessage({
+    const sent = wsDeps.value.sendMessage({
       type: 'sftp:upload:chunk',
       payload: { uploadId, chunkIndex: 0, data: '', isLast: true },
     });
+    if (sent === false) {
+      markUploadFailed('fileManager.errors.uploadFailed');
+      return;
+    }
     upload.progress = 100;
   }
 }

--- a/packages/frontend/src/composables/useWebRTCTunnel.test.ts
+++ b/packages/frontend/src/composables/useWebRTCTunnel.test.ts
@@ -8,6 +8,7 @@ import {
 describe('useWebRTCTunnel', () => {
   it('默认连接超时应长于后端 remote-gateway 连接窗口', () => {
     expect(DEFAULT_WEBRTC_CONNECT_TIMEOUT_MS).toBeGreaterThan(15_000);
+    expect(DEFAULT_WEBRTC_CONNECT_TIMEOUT_MS).toBeGreaterThanOrEqual(18_000);
   });
 
   it('WebRTCTunnel 默认配置应使用共享连接超时常量', () => {
@@ -17,6 +18,16 @@ describe('useWebRTCTunnel', () => {
     }) as unknown as { config: { connectTimeout: number } };
 
     expect(tunnel.config.connectTimeout).toBe(DEFAULT_WEBRTC_CONNECT_TIMEOUT_MS);
+  });
+
+  it('WebRTCTunnel 应保留调用方显式传入的 0 超时', () => {
+    const tunnel = new WebRTCTunnel({
+      signalingUrl: 'ws://backend/ws/webrtc-signaling',
+      tunnelUrl: 'ws://backend/ws/rdp-proxy?token=test',
+      connectTimeout: 0,
+    }) as unknown as { config: { connectTimeout: number } };
+
+    expect(tunnel.config.connectTimeout).toBe(0);
   });
 
   it('应导出 WebRTC tunnel 工厂函数', () => {

--- a/packages/frontend/src/composables/useWebRTCTunnel.ts
+++ b/packages/frontend/src/composables/useWebRTCTunnel.ts
@@ -43,7 +43,7 @@ export interface WebRTCTunnelConfig {
 
 // 前端超时不应短于后端 bridge.ts 中 remote-gateway 的 15s 连接窗口。
 // 否则 RDP/guacd 握手稍慢时，前端会先行超时并过早回退到 WebSocket。
-export const DEFAULT_WEBRTC_CONNECT_TIMEOUT_MS = 16_000;
+export const DEFAULT_WEBRTC_CONNECT_TIMEOUT_MS = 20_000;
 
 /** 连接状态 */
 type TunnelState = 'idle' | 'signaling' | 'connected' | 'failed' | 'disconnected';
@@ -95,7 +95,7 @@ export class WebRTCTunnel {
         { urls: 'stun:stun.chat.bilibili.com:3478' },
         { urls: 'stun:stun.miwifi.com:3478' },
       ],
-      connectTimeout: config.connectTimeout || DEFAULT_WEBRTC_CONNECT_TIMEOUT_MS,
+      connectTimeout: config.connectTimeout ?? DEFAULT_WEBRTC_CONNECT_TIMEOUT_MS,
     };
   }
 

--- a/packages/frontend/src/composables/useWebSocketConnection.test.ts
+++ b/packages/frontend/src/composables/useWebSocketConnection.test.ts
@@ -4,6 +4,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createWebSocketConnectionManager } from './useWebSocketConnection';
+import type { MessageHandler, WebSocketMessage } from '../types/websocket.types';
 
 // Mock logger
 const mockLog = vi.hoisted(() => ({
@@ -106,6 +107,13 @@ describe('useWebSocketConnection (createWebSocketConnectionManager)', () => {
   const createManager = (options?: {
     isResumeFlow?: boolean;
     getIsMarkedForSuspend?: () => boolean;
+    transport?: {
+      sid: string;
+      sendMessage: (message: WebSocketMessage) => boolean | void;
+      onMessage: (type: string, handler: MessageHandler) => () => void;
+      connect: () => void;
+      disconnect: () => void;
+    };
   }) => createWebSocketConnectionManager('session-1', '1', mockT, options);
 
   beforeEach(() => {
@@ -535,8 +543,9 @@ describe('useWebSocketConnection (createWebSocketConnectionManager)', () => {
       const ws = createdWebSockets[0];
       ws.simulateOpen();
 
-      manager.sendMessage({ type: 'test:message', payload: { data: 'test' } });
+      const sent = manager.sendMessage({ type: 'test:message', payload: { data: 'test' } });
 
+      expect(sent).toBe(true);
       expect(ws.send).toHaveBeenCalledWith(
         JSON.stringify({ type: 'test:message', payload: { data: 'test' } }),
       );
@@ -549,10 +558,45 @@ describe('useWebSocketConnection (createWebSocketConnectionManager)', () => {
       const ws = createdWebSockets[0];
       // 不调用 simulateOpen()
 
-      manager.sendMessage({ type: 'test:message', payload: {} });
+      const sent = manager.sendMessage({ type: 'test:message', payload: {} });
 
+      expect(sent).toBe(false);
       expect(ws.send).not.toHaveBeenCalled();
       expect(mockLog.warn).toHaveBeenCalled();
+    });
+
+    it('多路复用 transport 返回 false 时应透传发送失败', () => {
+      const transport = {
+        sid: 'mux-1',
+        sendMessage: vi.fn().mockReturnValue(false),
+        onMessage: vi.fn().mockReturnValue(vi.fn()),
+        connect: vi.fn(),
+        disconnect: vi.fn(),
+      };
+      const manager = createManager({ transport });
+
+      const sent = manager.sendMessage({ type: 'test:message', payload: {} });
+
+      expect(sent).toBe(false);
+      expect(transport.sendMessage).toHaveBeenCalledWith({
+        type: 'test:message',
+        payload: {},
+      });
+    });
+
+    it('多路复用 transport 未返回 false 时应视为发送成功', () => {
+      const transport = {
+        sid: 'mux-1',
+        sendMessage: vi.fn(),
+        onMessage: vi.fn().mockReturnValue(vi.fn()),
+        connect: vi.fn(),
+        disconnect: vi.fn(),
+      };
+      const manager = createManager({ transport });
+
+      const sent = manager.sendMessage({ type: 'test:message', payload: {} });
+
+      expect(sent).toBe(true);
     });
   });
 

--- a/packages/frontend/src/composables/useWebSocketConnection.ts
+++ b/packages/frontend/src/composables/useWebSocketConnection.ts
@@ -41,7 +41,7 @@ export function createWebSocketConnectionManager(
     getIsMarkedForSuspend?: () => boolean;
     transport?: {
       sid: string;
-      sendMessage: (message: WebSocketMessage) => void;
+      sendMessage: (message: WebSocketMessage) => boolean | void;
       onMessage: (type: string, handler: MessageHandler) => () => void;
       connect: () => void;
       disconnect: () => void;
@@ -336,28 +336,31 @@ export function createWebSocketConnectionManager(
   /**
    * 发送 WebSocket 消息
    */
-  const sendMessage = (message: WebSocketMessage) => {
+  const sendMessage = (message: WebSocketMessage): boolean => {
     // 多路复用模式：委托给 transport
     if (transport) {
       try {
-        transport.sendMessage(message);
+        return transport.sendMessage(message) !== false;
       } catch (error: unknown) {
         log.error(`[WebSocket ${instanceSessionId}] 多路复用发送消息失败:`, error, message);
+        return false;
       }
-      return;
     }
 
     if (ws.value && ws.value.readyState === WebSocket.OPEN) {
       try {
         const messageString = JSON.stringify(message);
         ws.value.send(messageString);
+        return true;
       } catch (error: unknown) {
         log.error(`[WebSocket ${instanceSessionId}] 序列化或发送消息失败:`, error, message);
+        return false;
       }
     } else {
       log.warn(
         `[WebSocket ${instanceSessionId}] 无法发送消息，连接未打开。状态: ${connectionStatus.value}, ReadyState: ${ws.value?.readyState}`,
       );
+      return false;
     }
   };
 

--- a/packages/frontend/src/features/terminal/Terminal.test.ts
+++ b/packages/frontend/src/features/terminal/Terminal.test.ts
@@ -481,6 +481,28 @@ describe('Terminal.vue', () => {
         expect.stringContaining('忽略 xterm addon 重复清理错误'),
       );
     });
+
+    it('xterm dispose 抛未知错误时应保留终端引用以便后续清理', async () => {
+      mockTerminalDispose.mockImplementationOnce(() => {
+        throw new Error('renderer cleanup failed');
+      });
+
+      const wrapper = mount(Terminal, {
+        props: { sessionId: 'session-1' },
+      });
+      await nextTick();
+      const exposed = wrapper.vm as any;
+
+      expect(() => wrapper.unmount()).not.toThrow();
+      expect(mockLogWarn).toHaveBeenCalledWith(
+        expect.stringContaining('xterm dispose 失败'),
+        expect.any(Error),
+      );
+
+      mockTerminalWrite.mockClear();
+      exposed.write('retry-cleanup-visible');
+      expect(mockTerminalWrite).toHaveBeenCalledWith('retry-cleanup-visible');
+    });
   });
 
   describe('滚动限制', () => {

--- a/packages/frontend/src/features/terminal/Terminal.vue
+++ b/packages/frontend/src/features/terminal/Terminal.vue
@@ -651,6 +651,7 @@ onBeforeUnmount(() => {
   }
 
   if (terminalInstance.value) {
+    let shouldClearTerminalRefs = true;
     try {
       terminalInstance.value.dispose();
     } catch (error: unknown) {
@@ -658,15 +659,15 @@ onBeforeUnmount(() => {
       if (errorMessage.includes('Could not dispose an addon that has not been loaded')) {
         log.debug(`[Terminal ${props.sessionId}] 忽略 xterm addon 重复清理错误: ${errorMessage}`);
       } else {
-        log.warn(
-          `[Terminal ${props.sessionId}] xterm dispose 失败，已忽略以避免关闭会话中断:`,
-          error,
-        );
+        shouldClearTerminalRefs = false;
+        log.warn(`[Terminal ${props.sessionId}] xterm dispose 失败，保留引用以便后续清理:`, error);
       }
     } finally {
-      terminalInstance.value = null;
-      outputEnhancerAddon = null;
-      searchAddon = null;
+      if (shouldClearTerminalRefs) {
+        terminalInstance.value = null;
+        outputEnhancerAddon = null;
+        searchAddon = null;
+      }
     }
   }
 


### PR DESCRIPTION
## 变更内容

- 修复 WebRTC bridge 外部 ws/wss 网关地址的 SSRF 校验协议映射，保留 remote-gateway WebSocket 配置路径，并避免错误消息泄露敏感 query。
- 修复上传开始和分块发送失败时的状态释放，避免上传槽位或 ACK 资源残留。
- 修复上传进度提前显示 100% 的情况，统一上传进度计算。
- 调整 WebRTC tunnel 默认连接超时，保留显式 0 超时配置。
- 优化 xterm dispose 异常处理，保留未知错误后的再次清理入口。
- 更新 remote-gateway WebSocket 路径配置说明。

## 验证

- npm run -s lint -- --max-warnings=0
- npm run -s typecheck:backend
- npm run -s typecheck:frontend
- npm run -w @nexus-terminal/backend test -- src/webrtc/bridge.test.ts src/sftp/sftp.service.test.ts src/sftp/sftp-file-content-operations.test.ts src/sftp/sftp-path-operations.test.ts src/sftp/sftp-path-query-operations.test.ts
- npm run -w @nexus-terminal/frontend test -- src/composables/useFileUploader.test.ts src/composables/useUploadChunkManager.test.ts src/composables/useWebRTCTunnel.test.ts src/composables/useWebSocketConnection.test.ts src/features/terminal/Terminal.test.ts

## 影响范围

- WebRTC remote desktop bridge
- SFTP upload
- frontend WebSocket send result handling
- terminal cleanup