### PR TITLE
Fix/silentely open issues

### DIFF
--- a/.env.localdocker
+++ b/.env.localdocker
@@ -1,0 +1,16 @@
+DEPLOYMENT_MODE=docker
+REMOTE_GATEWAY_API_BASE_LOCAL=http://localhost:9090
+REMOTE_GATEWAY_API_BASE_DOCKER=http://remote-gateway:9090
+REMOTE_GATEWAY_WS_URL_LOCAL=ws://localhost:8081
+REMOTE_GATEWAY_WS_URL_DOCKER=ws://remote-gateway:8081
+TRUST_PROXY_HOPS=1
+# Use the real browser-facing host here. 0.0.0.0 is a bind address, not a valid browser Origin.
+# Replace LOCAL_HOST_OR_DOMAIN with the exact host/IP/domain and port your browser uses to open the app.
+RP_ID=LOCAL_HOST_OR_DOMAIN
+RP_ORIGIN=http://LOCAL_HOST_OR_DOMAIN:18112
+ALLOWED_WS_ORIGINS=http://LOCAL_HOST_OR_DOMAIN:18112
+ALLOWED_ORIGINS=http://LOCAL_HOST_OR_DOMAIN:18112
+CORS_ALLOWED_ORIGINS=http://LOCAL_HOST_OR_DOMAIN:18112
+REMOTE_GATEWAY_API_TOKEN=local-test-token
+SESSION_COOKIE_SECURE=false
+LOG_LEVEL=debug

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,6 +1,7 @@
 name: Quality Gate
 
 on:
+  push:
   pull_request:
     branches:
       - main

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,80 @@
+services:
+  frontend:
+    build:
+      context: .
+      dockerfile: packages/frontend/Dockerfile
+    image: nexus-terminal-frontend:local
+    container_name: nexus-terminal-frontend-local
+    ports:
+      - "18112:8080"
+    depends_on:
+      backend:
+        condition: service_healthy
+      remote-gateway:
+        condition: service_healthy
+    networks:
+      - nexus-terminal-network-local
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/ > /dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  backend:
+    build:
+      context: .
+      dockerfile: packages/backend/Dockerfile
+    image: nexus-terminal-backend:local
+    container_name: nexus-terminal-backend-local
+    env_file:
+      - .env.localdocker
+    environment:
+      NODE_ENV: production
+      PORT: 3001
+    volumes:
+      - ./data-localdocker:/app/data
+    networks:
+      - nexus-terminal-network-local
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3001/api/v1/health > /dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+
+  remote-gateway:
+    build:
+      context: .
+      dockerfile: packages/remote-gateway/Dockerfile
+    image: nexus-terminal-remote-gateway:local
+    container_name: nexus-terminal-remote-gateway-local
+    env_file:
+      - .env.localdocker
+    environment:
+      GUACD_HOST: localhost
+      GUACD_PORT: 4822
+      REMOTE_GATEWAY_API_PORT: 9090
+      REMOTE_GATEWAY_WS_PORT: 8081
+      FRONTEND_URL: http://frontend
+      MAIN_BACKEND_URL: http://backend:3001
+      NODE_ENV: production
+      REMOTE_GATEWAY_API_TOKEN: ${REMOTE_GATEWAY_API_TOKEN}
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS}
+    networks:
+      - nexus-terminal-network-local
+    depends_on:
+      backend:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:9090/health > /dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+networks:
+  nexus-terminal-network-local:
+    driver: bridge
+    name: nexus-terminal-network-local

--- a/packages/backend/src/services/status-monitor.service.test.ts
+++ b/packages/backend/src/services/status-monitor.service.test.ts
@@ -455,6 +455,39 @@ describe('StatusMonitorService', () => {
       expect(mockWs.send).toHaveBeenCalledTimes(2);
     });
 
+    it('应将 iowait 计入空闲时间以避免高估 CPU 使用率', async () => {
+      let callCount = 0;
+      const cpuStats = [
+        'cpu  1000 100 500 5000 100 0 10 0 0 0',
+        'cpu  1100 120 550 5100 300 0 15 0 0 0',
+      ];
+
+      mockClient.exec.mockImplementation(
+        (_cmd: string, optionsOrCallback: unknown, callback?: Function) => {
+          const cb = typeof optionsOrCallback === 'function' ? optionsOrCallback : callback;
+          const idx = Math.min(callCount++, cpuStats.length - 1);
+          const output = buildBatchOutput({ PROC_STAT: cpuStats[idx] });
+          const stream = createMockStream(output);
+          cb(null, stream);
+        },
+      );
+
+      const mockWs = createMockWebSocket(1);
+      clientStates.set('session-cpu-iowait', {
+        sshClient: mockClient,
+        ws: mockWs,
+        dbConnectionId: 1,
+        statusIntervalId: undefined,
+      });
+
+      await service.startStatusPolling('session-cpu-iowait');
+      await vi.advanceTimersByTimeAsync(3000);
+      await vi.advanceTimersByTimeAsync(3000);
+
+      const secondData = JSON.parse(mockWs.send.mock.calls[1][0]);
+      expect(secondData.payload.status.cpuPercent).toBe(36.8);
+    });
+
     it('应正确解析系统负载', async () => {
       const batchOutput = buildBatchOutput({
         UPTIME: ' 14:30:01 up 10 days,  5:30,  2 users,  load average: 1.50, 2.00, 1.75',

--- a/packages/backend/src/services/status-monitor.service.ts
+++ b/packages/backend/src/services/status-monitor.service.ts
@@ -371,10 +371,33 @@ class HealthCheckCollector {
     try {
       const cpuLine = output.split('\n').find((line) => line.startsWith('cpu '));
       if (!cpuLine) return null;
+
       const fields = cpuLine.trim().split(/\s+/).slice(1).map(Number);
       if (fields.length < 4 || fields.slice(0, 4).some(Number.isNaN)) return null;
-      const idle = fields[3] + (Number.isNaN(fields[4]) ? 0 : fields[4]);
-      const total = fields.reduce((sum, v) => sum + (Number.isNaN(v) ? 0 : v), 0);
+
+      const [
+        userTime,
+        niceTime,
+        systemTime,
+        idleTime,
+        ioWaitTime = 0,
+        irqTime = 0,
+        softIrqTime = 0,
+        stealTime = 0,
+      ] = fields;
+
+      const idle = idleTime + (Number.isNaN(ioWaitTime) ? 0 : ioWaitTime);
+      const total =
+        userTime +
+        niceTime +
+        systemTime +
+        idleTime +
+        (Number.isNaN(ioWaitTime) ? 0 : ioWaitTime) +
+        (Number.isNaN(irqTime) ? 0 : irqTime) +
+        (Number.isNaN(softIrqTime) ? 0 : softIrqTime) +
+        (Number.isNaN(stealTime) ? 0 : stealTime) +
+        fields.slice(8).reduce((sum, value) => sum + (Number.isNaN(value) ? 0 : value), 0);
+
       if (Number.isNaN(total) || Number.isNaN(idle)) return null;
       return { total, idle };
     } catch (error: unknown) {

--- a/packages/backend/src/services/status-monitor.service.ts
+++ b/packages/backend/src/services/status-monitor.service.ts
@@ -373,7 +373,7 @@ class HealthCheckCollector {
       if (!cpuLine) return null;
       const fields = cpuLine.trim().split(/\s+/).slice(1).map(Number);
       if (fields.length < 4 || fields.slice(0, 4).some(Number.isNaN)) return null;
-      const idle = fields[3];
+      const idle = fields[3] + (Number.isNaN(fields[4]) ? 0 : fields[4]);
       const total = fields.reduce((sum, v) => sum + (Number.isNaN(v) ? 0 : v), 0);
       if (Number.isNaN(total) || Number.isNaN(idle)) return null;
       return { total, idle };

--- a/packages/backend/src/sftp/sftp-path.utils.test.ts
+++ b/packages/backend/src/sftp/sftp-path.utils.test.ts
@@ -30,6 +30,12 @@ describe('validateSafePath', () => {
     it('应允许根路径', () => {
       expect(validateSafePath('/')).toBe(true);
     });
+
+    it('应允许包含冒号的时间戳目录路径', () => {
+      expect(
+        validateSafePath('/home/honus/product/pve/backup/data/data/vm/100/2026-07-08T05:49:42Z'),
+      ).toBe(true);
+    });
   });
 
   describe('应拒绝路径穿越', () => {

--- a/packages/backend/src/sftp/sftp-path.utils.ts
+++ b/packages/backend/src/sftp/sftp-path.utils.ts
@@ -18,7 +18,7 @@ const UNSAFE_PATH_PATTERNS = [
 ];
 
 /** 允许的路径字符：Unicode 字母/数字、/、.、-、_、空格、(、) 等常见文件名符号 */
-const SAFE_PATH_PATTERN = /^[\p{L}\p{N}\/.\-_ ()@#+=,!{}~]+$/u;
+const SAFE_PATH_PATTERN = /^[\p{L}\p{N}\/.\-_ ()@#+=,!{}~:]+$/u;
 
 /**
  * 验证路径是否安全，不包含 Shell 注入风险

--- a/packages/backend/src/sftp/sftp.controller.test.ts
+++ b/packages/backend/src/sftp/sftp.controller.test.ts
@@ -151,6 +151,48 @@ describe('SFTP Controller', () => {
       expect(mockRes.setHeader).toHaveBeenCalledWith('Content-Type', 'application/octet-stream');
       expect(mockRes.setHeader).toHaveBeenCalledWith('Content-Length', '1024');
     });
+
+    it('应在多会话场景下优先使用 sessionId 精确匹配下载会话', async () => {
+      const staleSftp = {
+        lstat: vi.fn(),
+        createReadStream: vi.fn(),
+      };
+      const exactSftp = {
+        lstat: vi.fn((path, callback) => {
+          callback(undefined, {
+            isFile: () => true,
+            size: 512,
+          });
+        }),
+        createReadStream: vi.fn().mockReturnValue({
+          on: vi.fn().mockReturnThis(),
+          pipe: vi.fn(),
+        }),
+      };
+
+      clientStates.set('session-stale', {
+        ws: { userId: 1 } as AuthenticatedWebSocket,
+        dbConnectionId: 1,
+        sftp: staleSftp,
+      } as any);
+      clientStates.set('session-exact', {
+        ws: { userId: 1 } as AuthenticatedWebSocket,
+        dbConnectionId: 1,
+        sftp: exactSftp,
+      } as any);
+
+      mockReq.query = {
+        connectionId: '1',
+        sessionId: 'session-exact',
+        remotePath: '/test/exact.txt',
+      };
+
+      await downloadFile(mockReq as Request, mockRes as Response, mockNext);
+
+      expect(exactSftp.lstat).toHaveBeenCalledWith('/test/exact.txt', expect.any(Function));
+      expect(staleSftp.lstat).not.toHaveBeenCalled();
+      expect(mockRes.setHeader).toHaveBeenCalledWith('Content-Length', '512');
+    });
   });
 
   describe('downloadDirectory', () => {
@@ -211,6 +253,42 @@ describe('SFTP Controller', () => {
 
       expect(mockRes.status).toHaveBeenCalledWith(400);
       expect(mockRes.json).toHaveBeenCalledWith({ message: '指定的路径不是一个目录。' });
+    });
+
+    it('应在多会话场景下优先使用 sessionId 精确匹配目录下载会话', async () => {
+      const staleSftp = {
+        lstat: vi.fn(),
+      };
+      const exactSftp = {
+        lstat: vi.fn((path, callback) => {
+          callback(undefined, {
+            isDirectory: () => false,
+          });
+        }),
+      };
+
+      clientStates.set('session-stale', {
+        ws: { userId: 1 } as AuthenticatedWebSocket,
+        dbConnectionId: 1,
+        sftp: staleSftp,
+      } as any);
+      clientStates.set('session-exact', {
+        ws: { userId: 1 } as AuthenticatedWebSocket,
+        dbConnectionId: 1,
+        sftp: exactSftp,
+      } as any);
+
+      mockReq.query = {
+        connectionId: '1',
+        sessionId: 'session-exact',
+        remotePath: '/test/dir',
+      };
+
+      await downloadDirectory(mockReq as Request, mockRes as Response, mockNext);
+
+      expect(exactSftp.lstat).toHaveBeenCalledWith('/test/dir', expect.any(Function));
+      expect(staleSftp.lstat).not.toHaveBeenCalled();
+      expect(mockRes.status).toHaveBeenCalledWith(400);
     });
   });
 

--- a/packages/backend/src/sftp/sftp.controller.ts
+++ b/packages/backend/src/sftp/sftp.controller.ts
@@ -36,6 +36,7 @@ export const downloadFile = async (
 ): Promise<void> => {
   const { userId } = req.session;
   const connectionId = req.query.connectionId as string; // 从查询参数获取
+  const sessionId = req.query.sessionId as string | undefined; // 可选：优先绑定当前前端会话
   const remotePath = req.query.remotePath as string; // 从查询参数获取
 
   // 参数验证
@@ -60,12 +61,26 @@ export const downloadFile = async (
   }
 
   logger.debug(`SFTP 下载：正在查找用户 ${userId} 且连接 ID 为 ${targetDbConnectionId} 的会话...`);
-  for (const [sessionId, state] of clientStates.entries()) {
-    // 检查 userId 和 dbConnectionId 是否都匹配，并且 sftp 实例存在
-    if (state.ws.userId === userId && state.dbConnectionId === targetDbConnectionId && state.sftp) {
-      targetState = state;
-      logger.debug(`SFTP 下载：找到匹配的会话 (Session ID: ${sessionId})。`);
-      break;
+  if (sessionId) {
+    const exactState = clientStates.get(sessionId);
+    if (
+      exactState &&
+      exactState.ws.userId === userId &&
+      exactState.dbConnectionId === targetDbConnectionId &&
+      exactState.sftp
+    ) {
+      targetState = exactState;
+      logger.debug(`SFTP 下载：按 sessionId 精确命中会话 (${sessionId})。`);
+    }
+  }
+  if (!targetState) {
+    for (const [activeSessionId, state] of clientStates.entries()) {
+      // 检查 userId 和 dbConnectionId 是否都匹配，并且 sftp 实例存在
+      if (state.ws.userId === userId && state.dbConnectionId === targetDbConnectionId && state.sftp) {
+        targetState = state;
+        logger.debug(`SFTP 下载：找到匹配的会话 (Session ID: ${activeSessionId})。`);
+        break;
+      }
     }
   }
 
@@ -150,6 +165,7 @@ export const downloadDirectory = async (
 ): Promise<void> => {
   const { userId } = req.session;
   const connectionId = req.query.connectionId as string; // 从查询参数获取
+  const sessionId = req.query.sessionId as string | undefined; // 可选：优先绑定当前前端会话
   const remotePath = req.query.remotePath as string; // 从查询参数获取
 
   // 参数验证
@@ -176,12 +192,26 @@ export const downloadDirectory = async (
   logger.debug(
     `SFTP 文件夹下载：正在查找用户 ${userId} 且连接 ID 为 ${targetDbConnectionId} 的会话...`,
   );
-  for (const [sessionId, state] of clientStates.entries()) {
-    // 检查 userId 和 dbConnectionId 是否都匹配，并且 sftp 实例存在
-    if (state.ws.userId === userId && state.dbConnectionId === targetDbConnectionId && state.sftp) {
-      targetState = state;
-      logger.debug(`SFTP 文件夹下载：找到匹配的会话 (Session ID: ${sessionId})。`);
-      break;
+  if (sessionId) {
+    const exactState = clientStates.get(sessionId);
+    if (
+      exactState &&
+      exactState.ws.userId === userId &&
+      exactState.dbConnectionId === targetDbConnectionId &&
+      exactState.sftp
+    ) {
+      targetState = exactState;
+      logger.debug(`SFTP 文件夹下载：按 sessionId 精确命中会话 (${sessionId})。`);
+    }
+  }
+  if (!targetState) {
+    for (const [activeSessionId, state] of clientStates.entries()) {
+      // 检查 userId 和 dbConnectionId 是否都匹配，并且 sftp 实例存在
+      if (state.ws.userId === userId && state.dbConnectionId === targetDbConnectionId && state.sftp) {
+        targetState = state;
+        logger.debug(`SFTP 文件夹下载：找到匹配的会话 (Session ID: ${activeSessionId})。`);
+        break;
+      }
     }
   }
 

--- a/packages/backend/src/sftp/sftp.controller.ts
+++ b/packages/backend/src/sftp/sftp.controller.ts
@@ -76,7 +76,11 @@ export const downloadFile = async (
   if (!targetState) {
     for (const [activeSessionId, state] of clientStates.entries()) {
       // 检查 userId 和 dbConnectionId 是否都匹配，并且 sftp 实例存在
-      if (state.ws.userId === userId && state.dbConnectionId === targetDbConnectionId && state.sftp) {
+      if (
+        state.ws.userId === userId &&
+        state.dbConnectionId === targetDbConnectionId &&
+        state.sftp
+      ) {
         targetState = state;
         logger.debug(`SFTP 下载：找到匹配的会话 (Session ID: ${activeSessionId})。`);
         break;
@@ -207,7 +211,11 @@ export const downloadDirectory = async (
   if (!targetState) {
     for (const [activeSessionId, state] of clientStates.entries()) {
       // 检查 userId 和 dbConnectionId 是否都匹配，并且 sftp 实例存在
-      if (state.ws.userId === userId && state.dbConnectionId === targetDbConnectionId && state.sftp) {
+      if (
+        state.ws.userId === userId &&
+        state.dbConnectionId === targetDbConnectionId &&
+        state.sftp
+      ) {
         targetState = state;
         logger.debug(`SFTP 文件夹下载：找到匹配的会话 (Session ID: ${activeSessionId})。`);
         break;

--- a/packages/frontend/src/composables/file-manager/useFileManagerDownload.ts
+++ b/packages/frontend/src/composables/file-manager/useFileManagerDownload.ts
@@ -76,7 +76,7 @@ export function useFileManagerDownload(options: UseFileManagerDownloadOptions) {
       }
 
       const downloadPath = manager.joinPath(manager.currentPath.value, item.filename);
-      const downloadUrl = `/api/v1/sftp/download?connectionId=${dbConnectionId}&remotePath=${encodeURIComponent(downloadPath)}`;
+      const downloadUrl = `/api/v1/sftp/download?connectionId=${dbConnectionId}&sessionId=${encodeURIComponent(sessionId.value)}&remotePath=${encodeURIComponent(downloadPath)}`;
       log.info(`${logPrefix.value} Triggering download for ${item.filename}: ${downloadUrl}`);
 
       const link = document.createElement('a');
@@ -128,7 +128,7 @@ export function useFileManagerDownload(options: UseFileManagerDownloadOptions) {
     }
 
     const directoryPath = manager.joinPath(manager.currentPath.value, item.filename);
-    const downloadUrl = `/api/v1/sftp/download-directory?connectionId=${dbConnectionId}&remotePath=${encodeURIComponent(directoryPath)}`;
+    const downloadUrl = `/api/v1/sftp/download-directory?connectionId=${dbConnectionId}&sessionId=${encodeURIComponent(sessionId.value)}&remotePath=${encodeURIComponent(directoryPath)}`;
 
     log.info(
       `${logPrefix.value} Attempting directory download for ${item.filename}: ${downloadUrl}`,


### PR DESCRIPTION
## Summary by Sourcery

Prioritize session-bound SFTP downloads, refine resource monitoring accuracy, loosen safe path validation for backup directories, and add local Docker-based development setup with CI trigger adjustments.

New Features:
- Support explicit sessionId binding for SFTP file and directory downloads to select the correct backend session in multi-session scenarios.
- Provide a local Docker Compose stack for frontend, backend, and remote gateway services configured with health checks and shared networking.

Bug Fixes:
- Correct CPU usage calculation by treating iowait time as idle to avoid overestimating utilization.
- Allow colon characters in validated SFTP paths so timestamp-based backup directories are not incorrectly rejected.

Enhancements:
- Update frontend file manager download URLs to include the current sessionId so backend session matching is deterministic in multi-session use.
- Improve server-side CPU metrics aggregation logic for more robust handling of /proc/stat values.

CI:
- Trigger the quality gate workflow on both pushes and pull requests for main to run checks more consistently.

Tests:
- Add SFTP controller tests to verify sessionId takes precedence when selecting download sessions for files and directories.
- Add status monitor tests to validate the revised CPU percentage calculation including iowait as idle.
- Add sftp-path utility tests covering timestamp directory paths with colons.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SFTP downloads to target the correct session and support timestamped paths, and corrects CPU usage by counting iowait as idle with clearer CPU stat field names. Adds a local Docker setup for end-to-end testing and enables quality checks on push.

- **Bug Fixes**
  - File and directory downloads now pass and prioritize `sessionId`, preventing wrong-session downloads in multi-session cases.
  - Safe path validation allows `:`, so ISO timestamp directories are accepted.
  - CPU usage calculation treats iowait as idle and clarifies CPU stat field names.

- **New Features**
  - Local Docker compose setup (`docker-compose.local.yml`) with `.env.localdocker` for frontend, backend, and `remote-gateway` with health checks.
  - Quality workflow now runs on push events.

<sup>Written for commit 39b034be0b3ad2a6af0332eb53b53281c9e42762. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Silentely/nexus-terminal/pull/111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

